### PR TITLE
Event identity and delivery: strict-mode diagnostics, static facade, delivery policy, interned and typed identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,103 @@
+# Changelog
+
+All notable changes to this package are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.4.0] - 2026-08-14
+
+Event identity and delivery timing. Everything here is additive: no public API was removed
+or changed, so a 2.3.1 consumer that upgrades and changes nothing keeps working, with
+better diagnostics. Every step of adoption is opt-in and independently shippable — see
+`Documentation~/UPGRADING.md`, and `Documentation~/adr/0001-event-identity-and-delivery.md`
+for the reasoning, including the places the design's own earlier claims turned out to be
+wrong.
+
+### Added
+
+- `EventsFor<T>` — a static, lazily-initialized entry point, one closed type per enum
+  family. Needs no GameObject and no `[DefaultExecutionOrder]`, so the `Awake` race that
+  `EventsPublisherEnumsSingleton<T>` subclasses worked around cannot occur. The singleton
+  still works and now forwards to the same facade, so the two paths cannot disagree.
+- Delivery policy: `EventDelivery.Transient` / `Sticky` / `Replay`, declared per enum
+  member with `[EventDelivery(...)]` and swept at `BeforeSceneLoad`. A subscriber to a
+  `Sticky` event is delivered the retained `(sender, data)` immediately on subscribe, which
+  removes the need to mirror events into static `bool`s and poll them at `Awake`.
+  `RegisterEvent(name, policy)` is the escape hatch for names no enum can annotate.
+- `TryGetLast` — reads a retained value without subscribing, for a one-shot read, a
+  non-`MonoBehaviour`, or an editor tool.
+- `[EventEnum]` — registers a family before any scene loads, which matters when an event
+  name reaches the publisher as a raw string without the facade being touched.
+  `[EventEnum(Prefix = "...")]` resolves two enums with the same simple name projecting
+  onto the same event names, without renaming the type.
+- `EventRef` and `[EventName]` — an Inspector dropdown of real events instead of a
+  free-text string. Prefer `[EventName]` on an existing field: it leaves the field a
+  `string`, so names already baked into a `.unity` or `.prefab` survive. A value matching
+  no known event shows as `Missing/<value>` rather than being silently cleared.
+- `EventId` — an interned handle that is the publisher's internal identity. Handler
+  signatures are unchanged, so this needs nothing from consumers.
+- `EventId<TData>` with `[EventPayload(typeof(X))]` — a typed identity resolved once via
+  `EventsFor<T>.Id<X>(member)`. Publishing the wrong payload and writing a handler with the
+  wrong parameter type both become compile errors. Erasure holds in both directions: typed
+  publishes reach untyped subscribers, untyped publishes reach typed handlers, and
+  `SubscribeToAllEvents` still receives `object`.
+- `EventsPublisher.StrictMode` — reports publishing an unregistered name, and a publish
+  whose payload does not match the event's declaration, naming the sender. On by default in
+  the editor and development builds.
+- `EventsDiagnostics` — records every event subscribed to after it had already been
+  published, so the edge-or-level decision is read off a run rather than guessed.
+- **Window > Events > Upgrade Audit** — reflects over the consuming project and reads its
+  assets, reporting which upgrade steps it has and has not taken.
+- `TryGetEnum(string, out T)` and `GetEventName(T)` — allocation-free, so "all events"
+  handlers can stop slicing the name on `/` and calling `Enum.Parse` per published event.
+- 104 EditMode tests in `Tests/Editor`. Consumers must add the package to `testables` in
+  `Packages/manifest.json` for Unity to build them.
+
+### Changed
+
+- Callback dispatch uses a direct cast invoke instead of `Delegate.DynamicInvoke`,
+  removing a reflection dispatch and an `object[]` allocation per callback per publish.
+- A nested publish enqueues and returns rather than starting a second drain of the shared
+  queue. Ordering is unchanged; the intent is now explicit rather than incidental.
+- Retention is top-frame only. Every publisher frame is still dispatched to, but only the
+  frame that is top at publish time retains the value, so `Push`/`Pop` is a real scope.
+
+### Fixed
+
+- The prefix collision detector shipped in 2.3.x could never fire: its registry was a
+  static field inside a generic type, so each constructed type saw only its own prefix —
+  precisely the cross-type comparison the check exists to make. It now lives on the
+  non-generic `EventsRegistry`.
+- Null and empty event names are rejected instead of reaching `Dictionary.ContainsKey(null)`,
+  which throws `ArgumentNullException`.
+- `EventsPublisherEnumsSingleton.Awake` destroyed the existing `Instance` rather than the
+  duplicate that had just awoken.
+- `EventsUpgradeAudit` referenced `UnityEngine.DefaultExecutionOrderAttribute`; Unity's
+  class is named `DefaultExecutionOrder` with no suffix, so the editor assembly failed to
+  compile and took every other assembly in the project with it.
+- `package.json` declared a sample at `Samples~/Basic Usage` that does not exist in the
+  repository. Harmless for an immutable git package, but an embedded copy is scanned
+  eagerly and throws `DirectoryNotFoundException` on every scan.
+
+## [2.3.1] - 2026-02-24
+
+- `SubscribeToAll` for enums goes through the enum publisher, so the underlying event name
+  matches what the rest of the facade publishes.
+
+## [2.3.0] - 2026-02-24
+
+- Enum events publish as `"EnumTypeName/MemberName"` rather than the bare member name,
+  avoiding most collisions between two enums sharing a member name.
+
+## [2.2.0] - 2025-11-19
+
+- Menu items to clear events now and on exiting play mode; subscribe to all registered
+  events for an enum; list current subscribers.
+
+## [2.1.0] - 2025-08-17
+
+- Initial package layout: assembly definitions, editor tooling, event subscriber logging.
+
+[2.4.0]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.4.0
+[2.3.1]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.3.1

--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e1616e112e134fc09ee8a07570d2db0c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation~/UPGRADING.md
+++ b/Documentation~/UPGRADING.md
@@ -19,6 +19,12 @@ contains rather than what a generic guide assumes. Findings are marked:
 - **Suggestion** — a guess, or a judgement the tool cannot make for you.
 - **Ok** — already done.
 
+The distinction is load-bearing for step 3 in particular. A field is reported as an
+Action only when an actual asset holds a known event name in it; a field merely *named*
+like an event name is a Suggestion, and those do produce false positives — a `[TextArea]`
+field called `_events` that holds a log dump will be listed. Read them, do not batch-apply
+them.
+
 Before the last step, enter play mode and run the boot sequence, then refresh again. The
 delivery-policy evidence comes from what actually happened during a run.
 
@@ -35,7 +41,7 @@ Add the package to `testables` in `Packages/manifest.json`:
 { "testables": [ "com.crawfissoftware.eventspublisher" ] }
 ```
 
-Unity only builds a package's tests when the consuming project opts in. 99 EditMode
+Unity only builds a package's tests when the consuming project opts in. 104 EditMode
 tests then appear under **Window > General > Test Runner**. They were verified on a stub
 harness rather than in a real editor, so running them once in a real project is a genuine
 check, not a formality.

--- a/Documentation~/UPGRADING.md
+++ b/Documentation~/UPGRADING.md
@@ -1,0 +1,204 @@
+# Upgrading a project to EventsPublisher 2.4
+
+Nothing here is required. The package is source-compatible: a project that upgrades and
+changes nothing keeps working exactly as before, with better diagnostics. Every step
+below is opt-in and independently shippable.
+
+The design reasoning is in `adr/0001-event-identity-and-delivery.md`. This file is the
+operational version — what to do, in what order, and which parts a tool can decide for
+you.
+
+## Start with the audit
+
+**Window > Events > Upgrade Audit**, then **Refresh**.
+
+It reflects over the project and reads its assets, so it reports what *this* project
+contains rather than what a generic guide assumes. Findings are marked:
+
+- **Action** — a concrete step, discovered from evidence, safe to just do.
+- **Suggestion** — a guess, or a judgement the tool cannot make for you.
+- **Ok** — already done.
+
+Before the last step, enter play mode and run the boot sequence, then refresh again. The
+delivery-policy evidence comes from what actually happened during a run.
+
+**Copy report** puts the findings on the clipboard, which is how you hand them to an
+assistant along with `upgrade-prompt.md`.
+
+## The steps
+
+### 1. Enable the tests
+
+Add the package to `testables` in `Packages/manifest.json`:
+
+```json
+{ "testables": [ "com.crawfissoftware.eventspublisher" ] }
+```
+
+Unity only builds a package's tests when the consuming project opts in. 99 EditMode
+tests then appear under **Window > General > Test Runner**. They were verified on a stub
+harness rather than in a real editor, so running them once in a real project is a genuine
+check, not a formality.
+
+### 2. Mark the event enums — `[EventEnum]`
+
+Registers a family before any scene loads and populates the Inspector dropdowns.
+
+Watch for a prefix-collision error: two enums with the same simple name in different
+namespaces project onto the same event names and would silently share every event. Fix
+it with `[EventEnum(Prefix = "...")]` on **one** of them. Do not rename the enum type,
+and do not switch the projection to `Type.FullName` — that renames every event in the
+project to fix a local problem, breaking every name baked into a scene or prefab.
+
+### 3. Mark Inspector event names — `[EventName]`
+
+Scene data has no compile step, so a `[SerializeField] string` event name has no check of
+any kind. `[EventName]` turns it into a dropdown.
+
+**Add the attribute; do not change the field's type.** Converting a `string` field to
+`EventRef` changes its serialized shape, so Unity cannot carry the value across and every
+name already saved in a `.unity` or `.prefab` is lost. Use `EventRef` for new fields only.
+
+The audit finds these two ways. Fields whose value in an actual asset is a known event
+name are certain — that catches a field called `_trigger` that no naming heuristic would
+find. Fields merely *named* like event names are guesses, and marked as such.
+
+After marking, open each affected component. A value showing as `Missing/<name>` means
+that name is in no `[EventEnum]` enum — investigate rather than re-picking, because the
+publisher is keyed on exactly that string.
+
+### 4. Retire the execution-order workaround — `EventsFor<T>`
+
+`EventsPublisherEnumsSingleton<T>` needs a GameObject and assigns `Instance` in `Awake`,
+which is what any `[DefaultExecutionOrder(-10000)]` on its subclasses is for. That
+attribute orders `Awake` **within one scene load batch**, and an additively-loaded scene
+is a separate batch — so a scene loaded before the one hosting the singleton
+`NullReferenceException`s on `Instance`. The attribute never protected additive loading.
+
+`EventsFor<T>` is static and lazily initialized, so the race cannot occur:
+
+```csharp
+using GameFlowBus = CrawfisSoftware.Events.EventsFor<GameFlowEvents>;
+
+GameFlowBus.Publish(GameFlowEvents.GameStarting, this, null);
+```
+
+Then delete the singleton subclasses and the execution-order attributes. The old
+singleton still works and forwards to the same facade, so this can be done file by file.
+
+### 5. Remove per-publish `Enum.Parse`
+
+An "all events" handler that slices the name on `/` and calls `Enum.Parse` allocates a
+string and does a reflection lookup on **every published event**. Replace with
+`EventsFor<T>.TryGetEnum(eventName, out var value)`, which allocates nothing.
+
+### 6. Replace `bool` mirrors with delivery policy
+
+This is the largest win and the only step needing real judgement.
+
+The symptom: static `bool`s named like `IsInitialized` / `HasSignedIn`, set from event
+handlers, polled in `Awake` by anything that might have loaded too late to hear the
+event. Those mirrors drift — one that is declared and reset but never set is common — and
+they cannot carry the event's payload.
+
+**Let the audit tell you which events need this.** Enter play mode, run the boot
+sequence, refresh: every event whose subscribers arrived after it was published is
+listed, most affected first. That is the measured version of the question, and it
+routinely disagrees with the guess.
+
+Then decide, per event, **edge or level**:
+
+- **Edge** — a transition (*"just failed at a turn"*), only meaningful in sequence. Leave
+  it `Transient`. Replaying an edge is actively wrong: a late subscriber would act on a
+  transition that has since been superseded.
+- **Level** — a state (*"gameplay is ready"*), self-describing on its own. Mark it
+  `[EventDelivery(EventDelivery.Sticky)]`.
+
+An event that already carries a payload is usually a level — needing data to be useful is
+the tell.
+
+Where a level is currently expressed as **two opposing edges** — `Ready`/`NotReady`,
+`SignedIn`/`SignedOut`, `Paused`/`Resumed` — sticky alone is unsafe, because a late
+subscriber gets whichever half fired last regardless of what happened after. Model the
+level directly instead, carrying the value:
+
+| Edge pair | Level event | Payload |
+|---|---|---|
+| `GameplayReady` / `GameplayNotReady` | `GameplayReadyChanged` | `bool` |
+| `PlayerSignedIn` / `PlayerSignedOut` | `AuthStateChanged` | `AuthState` |
+| `Paused` / `Resumed` | `PauseStateChanged` | `bool` |
+
+Prefer an enum over `bool` wherever "not yet" is meaningful — a never-published sticky
+event does not invoke the subscriber at all, which `bool` cannot express.
+
+The edges are **not** deleted. Animation, SFX and analytics want the moment, not the
+state. Keep them `Transient` alongside the new level.
+
+Then delete each `bool` and its `Awake`-time poll. A subscriber to a `Sticky` event is
+delivered the retained value immediately on subscribe, **with the payload**. For code
+that needs the value without subscribing, use `TryGetLast`.
+
+### 7. Type the payloads — `[EventPayload]`
+
+`data` is an `object`, so a handler that casts it wrongly fails inside the handler, where
+the publisher catches it and logs an exception naming neither the expected type nor who
+published it.
+
+```csharp
+[EventEnum]
+public enum TempleRunEvents
+{
+    [EventPayload(typeof(PlayerFailedData))]
+    [EventDelivery(EventDelivery.Sticky)]
+    PlayerFailed,
+}
+
+private static readonly EventId<PlayerFailedData> Failed =
+    EventsFor<TempleRunEvents>.Id<PlayerFailedData>(TempleRunEvents.PlayerFailed);
+
+private void OnEnable()  => Failed.Subscribe(OnPlayerFailed);
+private void OnDisable() => Failed.Unsubscribe(OnPlayerFailed);
+private void Fail()      => Failed.Publish(this, new PlayerFailedData(...));
+
+// No cast. A wrong parameter type will not compile.
+private void OnPlayerFailed(string eventName, object sender, PlayerFailedData data) { }
+```
+
+Resolve the id **once**, into a `static readonly` field. Everything downstream of that
+line is compiler-checked; the line itself is checked at startup against the attribute.
+Two call sites declaring different types for the same event is the one mistake no
+compiler can catch, so it is reported when the second one is minted.
+
+Start with events that **already carry data** — those have a real type to declare and the
+most casts to delete. Leave an event unannotated if it has no payload or a genuinely
+variable one; no declaration means no checking, which is the intended default.
+
+Do not try to type Inspector-authored components from step 3. They hold their event name
+as data, not as a literal, so there is no type argument to write. `StrictMode` covers them
+instead: a publish whose payload does not match the declaration is reported at the
+publisher, naming the sender. **That report is the main reason to declare payload types
+in a project that still has raw-string publishes** — which most do, and will keep doing.
+
+## Things that stay true throughout
+
+- **Never rename a published event.** Names are serialized into scenes and prefabs;
+  renaming silently breaks every baked reference. All of the above is additive.
+- **Keep `EventsPublisher.StrictMode` on while migrating.** It reports an unregistered
+  name and a mismatched payload — the two mistakes steps 2, 3 and 7 can introduce.
+- **Erasure holds in both directions.** Typed publishes reach untyped subscribers,
+  untyped publishes reach typed handlers, and `SubscribeToAllEvents` still receives
+  `object` — so the global logger, event history and editor menus need no change at any
+  point. Migrate one event, one file, one step at a time.
+- **A `Replay` journal grows for the life of its publisher frame.** If you adopt
+  `Replay` for an accumulation, scope it: push a publisher frame when the owning scene
+  loads and pop it on unload.
+- **`EventId` needs nothing from you.** The publisher keys on an interned handle
+  internally and handler signatures did not change. It only becomes visible if you choose
+  to hold one.
+
+## Turning the diagnostic off
+
+`EventsDiagnostics.Enabled` defaults to on in the editor and development builds, off in
+release. Set it to `false` to disable recording entirely; it then costs one bool test per
+publish. `EventsDiagnostics.Reset()` clears what has been recorded, and is called
+automatically at the start of each play session so a report describes one run.

--- a/Documentation~/UPGRADING.md
+++ b/Documentation~/UPGRADING.md
@@ -90,7 +90,16 @@ GameFlowBus.Publish(GameFlowEvents.GameStarting, this, null);
 ```
 
 Then delete the singleton subclasses and the execution-order attributes. The old
-singleton still works and forwards to the same facade, so this can be done file by file.
+singleton still works and forwards to the same facade, so the call sites can move file by
+file.
+
+The deletion itself is not code-only, which is easy to miss. A subclass is a
+`MonoBehaviour`, so removing it orphans every instance authored into a scene and leaves a
+missing-script entry where a working singleton used to be. Find them by the subclass's
+script GUID and remove them; where the component is alone on its GameObject, remove the
+GameObject too and unlink its transform from the scene roots or its parent's `m_Children`.
+Verify nothing still references what you removed — this is the one part of the upgrade that
+edits `.unity` assets.
 
 ### 5. Remove per-publish `Enum.Parse`
 
@@ -139,6 +148,13 @@ event does not invoke the subscriber at all, which `bool` cannot express.
 
 The edges are **not** deleted. Animation, SFX and analytics want the moment, not the
 state. Keep them `Transient` alongside the new level.
+
+Check whether an event is the **source** of an auto-chain or bridge mapping before marking
+it `Sticky`. A retained event is redelivered to anything subscribing late through
+`SubscribeToAllEvents`, so the chain re-fires from that point. That is often the fix — a
+bridge in an additively-loaded scene that was silently missing the event now receives it —
+but the same mechanism can re-run a command or re-trigger a scene load. The maps are worth
+reading before the decision, not after.
 
 Then delete each `bool` and its `Awake`-time poll. A subscriber to a `Sticky` event is
 delivered the retained value immediately on subscribe, **with the payload**. For code

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -340,7 +340,44 @@ The pull path is a drop-in replacement for the `bool` check, except that it retu
 retires the mirror; `TryGetLast` is required rather than optional given the
 end-of-frame decision.
 
-### Independently: make the enum facades static
+### Implemented: `EventsFor<T>`
+
+Shipped. `EventsFor<T>` is a static, lazily-initialized facade; `EventsPublisherEnums<T>`
+remains the implementation and `EventsPublisherEnumsSingleton<T>` now forwards to
+`EventsFor<T>`, so the two paths share one facade and cannot disagree. Existing scene
+objects keep working unchanged.
+
+Lazy static initialization is *inherently* race-free for the facade's own events: any
+publish or subscribe goes through `EventsFor<T>`, which registers every member of `T`
+on first touch, so registration always precedes first use. No execution-order
+attribute and no scene object are involved.
+
+The one case it does not cover is an event name reaching the publisher as a raw
+string without the facade ever being touched — the Inspector-authored call sites.
+`[EventEnum]` marks an enum for registration at `BeforeSceneLoad`, which closes that
+gap until those call sites move to `EventRef`.
+
+Two supporting pieces:
+
+- **`EventsRegistry`** — non-generic, because a static field declared inside a generic
+  type exists once per *constructed* type. It owns the cross-family prefix registry
+  and the `SubsystemRegistration` reset.
+- **Static reset** — `SubsystemRegistration` runs before `BeforeSceneLoad` and drops
+  cached facades and prefix claims. A no-op when domain reload is enabled (the current
+  setting), correct when it is not. It deliberately does **not** clear
+  `EventsPublisher` itself; dropping live subscriptions stays the opt-in editor toggle.
+
+#### Defect found and fixed in the Stage 0 collision detector
+
+The detector shipped in Stage 0 **never fired**. `_claimedPrefixes` was a static field
+inside the generic `EventsPublisherEnums<T>`, so `EventsPublisherEnums<A>` and
+`EventsPublisherEnums<B>` each had their own dictionary containing only their own
+prefix — exactly the cross-type comparison the check exists to make was the one it
+could not see. Confirmed by constructing facades for two same-named enums in different
+namespaces and observing no error. The registry now lives on the non-generic
+`EventsRegistry` and the cross-family case is covered by a test.
+
+### Rationale: why the enum facades are static
 
 `EventsPublisherEnumsSingleton<T> : MonoBehaviour` requires a GameObject in a scene,
 and that requirement is itself the source of the `[DefaultExecutionOrder(-10000)]`
@@ -351,10 +388,8 @@ A static, lazily-initialized `EventsFor<T>` removes the `Awake` race entirely, n
 no execution-order attribute, and makes `EventsPublisherGameFlow`,
 `EventsPublisherUGS`, `EventsRegistration` and `GuiEventsPublisher` unnecessary.
 
-This is the single highest-value fix for the timing problem and is **independent of
-sticky events** — worth doing either way. It requires care around Unity's domain
-reload settings (`[RuntimeInitializeOnLoadMethod]` / `[InitializeOnEnterPlayMode]`)
-when *Enter Play Mode Options* has domain reload disabled.
+This was the single highest-value fix for the timing problem and is **independent of
+sticky events**. See *Implemented: `EventsFor<T>`* above.
 
 ---
 

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -1,7 +1,7 @@
 # ADR 0001 — Event Identity and Delivery Timing
 
-**Status:** Decision 1 accepted, Stage 0 implemented. Decision 2 fully specified;
-`EventsFor<T>` implemented, delivery policy not yet.
+**Status:** Decision 1 accepted, Stage 0 implemented. Decision 2 implemented
+(`EventsFor<T>`, `Transient`/`Sticky`/`Replay`, immediate replay, `TryGetLast`).
 **Date:** 2026-08-12
 **Applies to:** `com.crawfissoftware.eventspublisher` 2.3.1 and consumers
 (`EventsPublishingTesting`, `RunnerUGSTemplate`)
@@ -301,10 +301,28 @@ the `bool`.
 ### Reset scope
 
 A stale sticky value replaying into a fresh play session is a regression relative to
-today. The `IStackEventsPublisher` push/pop stack is the natural scope: a sticky
-value lives in the publisher frame it was published into, and `Pop()` discards it.
-`Clear()` must drop sticky state too, and `ClearEventsMenu`'s existing
+today. The `IStackEventsPublisher` push/pop stack is the natural scope: a retained
+value lives in the publisher frame that was top when it was published, and `Pop()`
+discards it. `Clear()` drops retained state too, and `ClearEventsMenu`'s existing
 "clear on exiting play mode" toggle already covers the editor loop.
+
+#### Correction: retention is top-frame only, not per-frame
+
+An earlier draft said a retained value "lives in the frame it was published into"
+without noticing that `EventsPublisher.PublishEvent` dispatches to **every** frame in
+the stack. Retaining wherever the event was dispatched would therefore have written
+the value into *all* frames — so `Pop()` would discard nothing, because a copy would
+still be sitting in the frames underneath. The scoping story this ADR relies on for
+`Replay` would not have worked at all.
+
+Caught by a test asserting that a value published before a `Push()` survives the
+matching `Pop()`; it returned the inner frame's value instead.
+
+Dispatch and retention are now separated: every frame is still dispatched to, so
+subscribers underneath continue to hear the event, but only the frame that is top at
+publish time retains it. `TryGetLast` on the stack searches top-down and returns the
+first frame holding a value. `Push`/`Pop` is consequently a real scope, which is what
+makes the `Replay` scoping guidance actionable.
 
 ### Replay timing — DECIDED: immediate, on subscribe
 
@@ -374,6 +392,32 @@ editor tool. It still returns the payload, which the `bool` mirror never could.
 `Subscribe(e, cb, Immediate | Deferred)` was considered and rejected. One default,
 and a subscriber needing deferral does it itself in a line. Adding the knob before
 anything needs it moves the decision to every call site.
+
+### Implemented: delivery policy
+
+Shipped. `EventDelivery` (`Transient`/`Sticky`/`Replay`) with
+`[EventDelivery(...)]` on enum members, read once at facade construction; the
+publisher then does a dictionary lookup per publish rather than any reflection.
+
+- **Policy registry is stack-global**, on `EventsRegistry`; retained values are
+  per-frame. `RegisterEvent(name, delivery)` on `IEventsPublisher<T>` is the escape
+  hatch for names no enum can annotate.
+- **First declaration wins**, a differing second one is reported. Registering a name
+  *without* a policy — as `SubscribeToEvent` does implicitly — records nothing, so an
+  early subscriber cannot pin an event to `Transient` and silently turn a later
+  `[EventDelivery(Sticky)]` into a no-op. This resolves race 2 structurally, so the
+  planned implicit/explicit upgrade mechanism was not needed and no longer appears.
+- **Replay is immediate**, routed through the shared callback queue. A `Subscribe`
+  made from inside a handler during an active drain enqueues and runs in order.
+- **`TryGetLast`** is enum-keyed on the facades, string-keyed on the publisher.
+- **Journal growth past `EventsRegistry.JournalWarningThreshold`** is reported, never
+  truncated.
+
+Removing implicit registration from `SubscribeToEvent`, listed under the policy
+decision, is **deferred to Stage 1**. Doing it now would break the Inspector-authored
+subscribe call sites in `RunnerUGSTemplate`, which cannot move to a typed control
+until `EventRef` exists. It is not needed for policy correctness given the point
+above.
 
 ### Implemented: `EventsFor<T>`
 

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -101,12 +101,39 @@ This preserves `SubscribeToAllEvents` and every tool built on it, unchanged.
 - Null/empty guards on event names.
 - Allocation-free `TryGetEnum` so consumers stop calling `Enum.Parse`.
 
-**Stage 1 — close the write side.** Demote the public `string` overloads to
-`internal`, or mark `[Obsolete]` first for package consumers. Authored code goes
-through an enum facade. The typo class largely disappears with no new types.
+**Stage 1 — REVISED: the write side cannot be closed, and does not need to be.**
 
-Blocked on the Inspector-authored strings above: those call sites need a typed
-Inspector control before the string API can be closed. See Open Questions.
+As originally written this stage demoted the public `string` overloads to `internal`
+so that authored code had to go through an enum facade. That is not implementable,
+and attempting it revealed the goal was mis-stated.
+
+A component whose event is chosen in the Inspector holds that name as **data, not as
+a literal**, and must still hand a string to the publisher at runtime.
+`FireEventAfterSceneLoads`, `CloseSceneOnEvent`, `FireEventWhenSceneCloses`,
+`LoadSceneAfterGameControlEvent`, `TimedEvent` and the `Test_AutoFire*` scripts all do
+exactly this — and they still do it *after* migrating to `EventRef`, because the
+reference resolves to a string at the call. Closing the API would break every one of
+them permanently, not just until they migrate. The editor's `EventMenu`, which
+publishes a name picked from the registered list, is in the same position.
+
+The hazard was never the string API. It was **a name being typed by hand with nothing
+to check it**. That is closed at the authoring step instead:
+
+- `EventsFor<T>` — compile-checked, for names known in code.
+- `EventRef` / `[EventName]` — a dropdown of real events, for names authored in the
+  Inspector.
+- `StrictMode` — reports a publish of a name nothing registered, at runtime.
+- `EventRef` overloads on `IEventsPublisher<string>` (extension methods, so no
+  implementer changes) — so an authored call site never unwraps the string itself.
+
+With those in place the remaining raw-string surface is used only for names that are
+genuinely dynamic, which is what it is for. It stays public and is not marked
+`[Obsolete]`: marking it would flag `EventsPublisherEnums<T>`'s own legitimate use of
+it as the implementation substrate, and every dynamic call site, for no gain.
+
+Removing implicit registration from `SubscribeToEvent` — the one piece of the original
+Stage 1 still worth doing — is deferred until the Inspector call sites have moved to
+`EventRef`, since it would break subscribing to a name that is not pre-registered.
 
 **Stage 2 — `EventId` as identity.**
 
@@ -133,14 +160,14 @@ Stage 0 lands, whereas a wrong payload cast fails inside a handler.
 
 ### Rejected for now
 
-- **Switching the enum prefix to `Type.FullName`.** This closes the residual
-  collision hole (two enums with the same simple name in different namespaces), but
-  the projected names are serialized into `.unity` and `.prefab` assets. Changing
-  the scheme would silently break every baked reference — the exact rename hazard
-  this ADR argues against. Stage 0 ships a collision *detector* instead.
-  **Reopened** — see Open Question 1. This rejection rests entirely on the baked
-  strings; if the scene objects move onto enums, `FullName` becomes viable and the
-  collision detector can be retired.
+- **Switching the enum prefix to `Type.FullName`.** REJECTED, now permanently. It
+  closes the residual collision hole (two enums with the same simple name in different
+  namespaces), but renames *every* event in the project to do it, breaking every name
+  serialized into a `.unity` or `.prefab` asset — the exact rename hazard this ADR
+  argues against, applied globally to fix a local problem.
+  `[EventEnum(Prefix = "...")]` supersedes it: an explicit prefix on the one enum that
+  collides, leaving every other name untouched. The Stage 0 collision *detector* is
+  what surfaces the need, and now has a fix to point at rather than "rename the type".
 - **Message-type-as-identity** (`readonly record struct GameStarted(int Score)`,
   MediatR/MessagePipe shape). The idiomatic C# endpoint: the CLR type is the
   identity, namespaces make collisions impossible, rename refactoring is safe, and

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -306,40 +306,74 @@ value lives in the publisher frame it was published into, and `Pop()` discards i
 `Clear()` must drop sticky state too, and `ClearEventsMenu`'s existing
 "clear on exiting play mode" toggle already covers the editor loop.
 
-### Replay timing — DECIDED: end of frame, paired with a synchronous pull
+### Replay timing — DECIDED: immediate, on subscribe
 
-Sticky replay is deferred to **end of frame** rather than fired inline during
-`SubscribeToEvent`. Inline replay would run a handler mid-`Awake`, before `Start` and
-possibly before other scene objects exist; end-of-frame avoids that re-entrancy
-entirely.
+Sticky replay fires **inline during `Subscribe`**, routed through the existing
+callback queue.
 
-This choice has a consequence that must be handled, or sticky will not actually
-retire the `bool` mirror. Today's pattern reads state **synchronously**:
+#### Reversal of an earlier decision
 
-```csharp
-if (UGS_State.IsCheckForExistingSession) // Missed the event being published.
-```
+This ADR previously recorded end-of-frame replay, paired with a mandatory
+`TryGetLast` pull so that `Awake`/`Start` readers were not regressed. That decision
+was mine, it was presented as the "safer" option, and the reasoning was weaker than
+the presentation implied. It is reversed here.
 
-With end-of-frame replay, a component subscribing in `Awake` is not invoked until the
-end of that frame — so the value is still unavailable in `Start`. End-of-frame is
-strictly *later* than what the `bool` provides now, and on its own is a regression for
-this call site.
+The tell is structural: **end-of-frame creates the gap that `TryGetLast` then
+patches.** A choice that requires a second mechanism to compensate for it is not
+carrying its weight. Weighing the two honestly:
 
-Sticky is therefore paired with a synchronous pull alongside the push:
+- **End-of-frame buys:** the handler does not run mid-`Awake`.
+- **End-of-frame costs:** between `Awake` and end of frame, the subscriber has
+  subscribed but has not been told the current state. It is wrong about the world for
+  the rest of the frame, with no recourse — except to call `TryGetLast`
+  synchronously, in `Awake`.
+
+That last point dissolves the original argument. If reading the value synchronously
+during `Awake` were genuinely hazardous, `TryGetLast` in `Awake` would be equally
+hazardous. It is not, so the objection to immediate replay does not hold.
+
+#### The remaining objection is under the subscriber's control
+
+"The handler might run before the subscriber is fully constructed" is real, but
+immediate replay fires *exactly when `Subscribe` is called* — a moment the subscriber
+already chooses. Subscribing at the end of `Awake`, in `OnEnable`, or in `Start` is
+sufficient.
+
+That is local, visible discipline in one file, in exchange for the invisible global
+constraint (`[DefaultExecutionOrder]`, scene load order) that this work exists to
+remove. Trading a global invisible constraint for a local visible one is the right
+direction.
+
+#### Accepted costs
+
+1. **Re-entrancy into the drain.** `Subscribe` called from inside a handler — during
+   an active publish drain — must not invoke a callback mid-drain. The replay is
+   routed through the same `_callbackQueue`: if a drain is in progress it enqueues and
+   runs in order, otherwise it invokes immediately. The `_isDraining` guard added in
+   Stage 0 is the hook. **This is the part that needs care in implementation.**
+2. **Structural work in a handler.** A handler that loads or unloads scenes during the
+   `Awake` of a still-loading scene is dicey in Unity. Such a subscriber defers itself
+   (`StartCoroutine`, or a flag acted on in `Update`) — and would face the same
+   problem via `TryGetLast`.
+3. **Staggered delivery.** Subscribers see a replayed event at different times
+   depending on when each subscribes. Inherent to replay in any form, end-of-frame
+   included.
+
+#### `TryGetLast` is retained, but demoted
 
 ```csharp
 bool TryGetLast(string eventName, out object sender, out object data);
 ```
 
-- **Push** (end-of-frame replay) — the normal reactive path, no handler running
-  mid-`Awake`.
-- **Pull** (`TryGetLast`) — for code that genuinely needs the value during
-  `Awake`/`Start`.
+It is no longer required as compensation. It remains useful for code that wants the
+value **without subscribing at all** — a one-shot read, a non-`MonoBehaviour`, an
+editor tool. It still returns the payload, which the `bool` mirror never could.
 
-The pull path is a drop-in replacement for the `bool` check, except that it returns
-**the payload**, which a `bool` never could. The push/pull pair together is what
-retires the mirror; `TryGetLast` is required rather than optional given the
-end-of-frame decision.
+#### Rejected: a per-subscription override
+
+`Subscribe(e, cb, Immediate | Deferred)` was considered and rejected. One default,
+and a subscriber needing deferral does it itself in a line. Adding the knob before
+anything needs it moves the decision to every call site.
 
 ### Implemented: `EventsFor<T>`
 
@@ -479,7 +513,10 @@ Not fixed here; they are not identity or timing problems.
    enum families. First declaration wins, conflicts are an error, implicit
    registration is removed from `SubscribeToEvent`. See *Declaring the policy*.
 2. **Sticky replay timing** — end of frame, paired with a synchronous
-   `TryGetLast` pull so `Awake`/`Start` code is not regressed. See *Replay timing*.
+   `TryGetLast` pull so `Awake`/`Start` code is not regressed.
+   **Superseded** — replay is immediate, on subscribe, routed through the existing
+   callback queue; `TryGetLast` is retained but demoted from required to convenience.
+   See *Replay timing* for the reversal and its reasoning.
 3. **Edge→level migration** — model levels directly; do not ship invalidation pairs.
    Edges are retained as `Transient` alongside the new `Sticky` levels. See
    *Edge vs. level*.
@@ -558,7 +595,7 @@ A sticky event has three possible states, and publishing only reaches two of the
 | State | Late subscriber sees |
 |---|---|
 | Never published | not invoked |
-| Has a retained value | the value, at end of frame |
+| Has a retained value | the value, immediately on subscribe |
 | **Had a value, now untrue** | **the stale value** |
 
 The third state is the gap. The distinction is *value changed* versus *value became

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -453,28 +453,86 @@ Not fixed here; they are not identity or timing problems.
    Statics therefore still reset on entering play mode today, so a static registry is
    currently safe. The project is one checkbox away from statics persisting, so the
    registry resets explicitly rather than relying on that.
+5. **Inspector call sites** — adopt a serializable `EventRef` (enum type name +
+   member name) with a two-dropdown property drawer, rather than a concrete
+   per-family subclass of each generic component. Keeps one component per behavior,
+   avoids the eight-components × four-families cross product, and removes typos at
+   the authoring step, which is the only step that exists for scene data. This
+   unblocks Stage 1 and reopens `Type.FullName` (see *Rejected for now*).
+6. **`Replay` policy** — in scope. All three policies ship: `Transient`, `Sticky`,
+   `Replay`.
 
-## Open questions
+## Sticky reset granularity — recommendation, pending confirmation
 
-1. **Inspector call sites.** These block Stage 1. The owner expects to be able to
-   move the scene-object strings onto enums without much difficulty; if so, three
-   consequences follow and should be confirmed before starting:
-   - Stage 1 (making the `string` API `internal`) becomes viable.
-   - The `Type.FullName` rejection above is **reopened** — that rejection rests
-     entirely on names being baked into `.unity`/`.prefab` assets. Remove the baked
-     strings and switching to `FullName` closes the namespace-collision hole for
-     free, at which point the Stage 0 collision detector can be retired.
-   - Beware the cross product. Unity cannot serialize `System.Enum` polymorphically,
-     so a per-family concrete subclass is needed for each generic component — eight
-     string-using components across four enum families is up to 32 classes if done
-     naively. A serializable `EventRef` (enum type name + member name, with a
-     two-dropdown property drawer) keeps one component per behavior, avoids typos,
-     and projects to the same event name. That is the same "string is a projection,
-     not the identity" principle applied to serialized data, and is likely the
-     better fit for Inspector fields specifically.
-2. **`Replay` policy** — is the full-journal variant wanted at all, or is
-   `Transient` + `Sticky` sufficient? `EventHistory` is the only obvious consumer,
-   and it already subscribes to all events.
-3. **Sticky reset granularity** — `Pop()` and `Clear()` are settled. Is a
-   per-event `Invalidate(name)` also needed for cases where a level becomes unknown
-   rather than changing value?
+`Pop()` and `Clear()` are settled but coarse. The remaining question is whether a
+per-event `Invalidate(name)` is also needed.
+
+### The gap
+
+A sticky event has three possible states, and publishing only reaches two of them:
+
+| State | Late subscriber sees |
+|---|---|
+| Never published | not invoked |
+| Has a retained value | the value, at end of frame |
+| **Had a value, now untrue** | **the stale value** |
+
+The third state is the gap. The distinction is *value changed* versus *value became
+unknown*:
+
+- `DifficultyChanged(Hard)` → `DifficultyChanged(Easy)` is a **change**. Publishing
+  handles it; no invalidation needed.
+- `RemoteConfigUpdated(config)` → the player signs out and the session's config is no
+  longer valid. There is no new config to publish. Publishing
+  `RemoteConfigUpdated(null)` asserts *"here is the new config, it is null"*, which is
+  a different and weaker claim than *"there is no current answer"* — and it forces
+  every subscriber to null-check.
+
+The contracts differ at the subscriber: after `Invalidate`, a late subscriber is not
+invoked at all, exactly as if the event had never been published. After
+`Publish(null)`, it is invoked with null.
+
+The test is therefore: **is there a meaningful new value? If yes, publish. If the
+answer becomes "no answer", invalidate.**
+
+### Why Unity makes this pressing rather than academic
+
+Sticky retains `object sender` and `object data` indefinitely. `sender` is typically a
+`MonoBehaviour`, and `data` may be an arbitrary object graph rooted in the scene.
+
+When that scene unloads, the C++ object is destroyed but the managed wrapper stays
+alive as long as the sticky cache references it — the "fake null" state, where the
+reference is non-null to the CLR but `== null` under Unity's overloaded operator. Two
+consequences:
+
+- **Stale replay.** A subscriber in the *next* level receives a retained value
+  pointing at destroyed objects.
+- **Retention.** The wrapper itself is small, but the payload graph is not; a sticky
+  event can hold a whole level's worth of objects past unload.
+
+So some mechanism to drop retained values is required, not optional. `Invalidate` is
+the manual form.
+
+### Recommendation
+
+Adopt `Invalidate(name)`, scoped narrowly as **cache hygiene**:
+
+1. **Silent.** It drops the retained value and affects only future late subscribers.
+   It does not notify current subscribers.
+2. **Auto-drop a destroyed sender.** At replay time, if the retained sender is a
+   `UnityEngine.Object` that compares equal to null, drop the entry and do not
+   replay. This defends the common case without requiring discipline. It cannot
+   detect scene references inside `data`, so manual `Invalidate` on teardown is still
+   needed.
+3. **Consider per-scene frames.** `IStackEventsPublisher` already models scoping: if
+   an additive gameplay scene pushed a frame on load and popped it on unload, sticky
+   values published into it would be discarded automatically. Nothing pushes per
+   scene today — `Push()` is called once from the static constructor — so this is new
+   discipline rather than existing behavior, but it would make most manual
+   invalidation unnecessary.
+
+The scoping rule that keeps this from sprawling: **if subscribers need to react to
+the invalidation, it is not an invalidation — it is a state value.** Model it as an
+explicit "unknown" member of the level's value domain, per the existing guidance to
+prefer an enum over `bool` wherever "not yet" is meaningful. `Invalidate` exists only
+so that a late subscriber is not told something false.

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -1,0 +1,345 @@
+# ADR 0001 — Event Identity and Delivery Timing
+
+**Status:** Proposed
+**Date:** 2026-08-12
+**Applies to:** `com.crawfissoftware.eventspublisher` 2.3.1 and consumers
+(`EventsPublishingTesting`, `RunnerUGSTemplate`)
+
+---
+
+## Context
+
+The publisher keys every event on a `string`. Enum-based facades
+(`EventsPublisherEnums<T>`) project an enum onto `"EnumTypeName/MemberName"`, and
+that string becomes the identity used by the dictionary, the subscribers, and the
+global logger.
+
+Two separate problems follow from this design. They are usually discussed
+together, but they have different causes and different fixes.
+
+1. **Identity** — the string is the identity, so nothing checks that a call site
+   reproduced it correctly.
+2. **Timing** — under additive scene loading, a subscriber's `Awake` may run after
+   an event has already been published, so the subscriber never sees it.
+
+The second problem is currently worked around by mirroring events into static
+`bool` state and polling that state at `Awake`.
+
+### Why the string exists
+
+The string exists to serve the *observation* side: `SubscribeToAllEvents` feeds
+`EventLoggingMenu`, `EventHistory`, and `DebugEventFileLogger`, all of which need a
+readable name for an event whose concrete type they do not know.
+
+That requirement is real, but it only constrains the **read** side. The
+**publication** side never needed to be stringly-typed. The current design erases
+to a string at publish time, which discards the type information before anything
+can validate it.
+
+---
+
+## Evidence from the codebase
+
+Observed in `RunnerUGSTemplate` at `dd7537f`:
+
+- **Missed events are handled by hand.** `UGS_State` declares eight static
+  `bool`s under the comment *"Keep track of potentially missed events in scenes
+  that load after UGS initialization"*. `PlayerAuthenticationManager.cs:50` reads
+  `if (UGS_State.IsCheckForExistingSession)` with the comment
+  *"// Missed the event being published."*
+- **The mirror drifts.** `UGS_State.IsGameReady` is declared and reset but never
+  assigned `true`. Any subscriber polling it is silently dead.
+- **The mirror loses the payload.** A `bool` records *that* `RemoteConfigUpdated`
+  fired, not *what* the config was. Late subscribers need a second state holder to
+  recover the data.
+- **Every handler needs two code paths.** A subscription for the future, plus an
+  `Awake`-time poll for the past. The poll is easy to forget and impossible to
+  check.
+- **Identity round-trips through the string.**
+  `GameFlowAutoEventFlow.AutoFireGameFlowEventFromGameFlowEvent` slices the string
+  on `'/'` and calls `Enum.Parse<GameFlowEvents>` — a per-publish allocation plus a
+  reflection-backed lookup, to recover an enum the publisher already had.
+- **Event names are authored in the Inspector.**
+  `[SerializeField] private string _eventName` appears in `TimedEvent` (defaulting
+  to `"ERROR"`), `FireEventAfterSceneLoads`, `CloseSceneOnEvent`,
+  `FireEventWhenSceneCloses`, `LoadSceneAfterGameControlEvent`, and the
+  `Test_AutoFire*` scripts. These bypass the enum facade entirely and have no
+  compile-time check of any kind.
+- **Names are baked into scene assets.** `GameFlowEvents/GameplayReady`,
+  `UGS_EventsEnum/RemoteConfigUpdated` and eight others appear as literals inside
+  `.unity` and `.prefab` files.
+- **Ordering is load-bearing and invisible.** `EventsPublisherGameFlow`,
+  `EventsPublisherUGS`, `EventsPublisherTempleRun` and
+  `EventsPublisherUserInitiated` each carry `[DefaultExecutionOrder(-10000)]` so
+  their `Awake` sets `Instance` before subscribers run. `DefaultExecutionOrder`
+  orders `Awake` calls *within a scene load batch*; an additively-loaded scene is a
+  separate batch. A scene loaded before the one hosting the publisher singleton
+  will `NullReferenceException` on `Instance`.
+
+---
+
+## Decision 1 — Identity: the string becomes a projection
+
+**The string should be a projection (`.Name`), not the identity.**
+
+Identity becomes a token the compiler owns. `.Name` is derived, and exists only for
+display, serialization, and the erased observer channel. Erase at the observation
+boundary, not at the publication boundary.
+
+This preserves `SubscribeToAllEvents` and every tool built on it, unchanged.
+
+### Staged path
+
+**Stage 0 — make the hazard loud.** Non-breaking. *(Implemented; see Consequences.)*
+
+- Strict-mode diagnostic when publishing an unregistered name, under
+  `UNITY_EDITOR || DEVELOPMENT_BUILD`. Converts silent no-ops into visible errors.
+- Detect two enum types projecting to the same `"TypeName/"` prefix and report it.
+- Replace `Delegate.DynamicInvoke` with a direct cast invoke.
+- Repair the exception handler and the callback-queue drain.
+- Null/empty guards on event names.
+- Allocation-free `TryGetEnum` so consumers stop calling `Enum.Parse`.
+
+**Stage 1 — close the write side.** Demote the public `string` overloads to
+`internal`, or mark `[Obsolete]` first for package consumers. Authored code goes
+through an enum facade. The typo class largely disappears with no new types.
+
+Blocked on the Inspector-authored strings above: those call sites need a typed
+Inspector control before the string API can be closed. See Open Questions.
+
+**Stage 2 — `EventId` as identity.**
+
+```csharp
+public readonly struct EventId : IEquatable<EventId>
+{
+    private readonly int _id;                    // interned; dictionary key
+    public string Name => EventNames.Get(_id);   // projection — observers only
+}
+```
+
+`EventsPublisherEnums<T>` becomes the interner rather than a string factory, so the
+enum authoring surface is unchanged. The internal dictionary keys on `int`: no
+string hashing, no collisions, no allocation.
+
+**Stage 3 — type the payload.** `EventId<TData>`, with
+`Publish<TData>(EventId<TData> id, object sender, TData data)`. A wrong payload
+becomes a compile error rather than an `InvalidCastException` inside a swallowed
+callback. Erased subscribers still receive `object`, so the logger, `EventHistory`,
+and the editor menus do not change.
+
+`object data` is the larger hazard of the two — a typo'd key fails loudly once
+Stage 0 lands, whereas a wrong payload cast fails inside a handler.
+
+### Rejected for now
+
+- **Switching the enum prefix to `Type.FullName`.** This closes the residual
+  collision hole (two enums with the same simple name in different namespaces), but
+  the projected names are serialized into `.unity` and `.prefab` assets. Changing
+  the scheme would silently break every baked reference — the exact rename hazard
+  this ADR argues against. Stage 0 ships a collision *detector* instead. Revisit
+  alongside a scene-asset migration.
+- **Message-type-as-identity** (`readonly record struct GameStarted(int Score)`,
+  MediatR/MessagePipe shape). The idiomatic C# endpoint: the CLR type is the
+  identity, namespaces make collisions impossible, rename refactoring is safe, and
+  the logger prints the type name. Rejected because it costs the enum authoring
+  ergonomics and the `Enum.GetValues` iteration that `EventMenu` and
+  `SubscribeToAllEnumEvents` depend on. Reasonable for new domains.
+- **`ScriptableObject` event channels.** Unity-native and Inspector-friendly, which
+  would fix the `[SerializeField] string` call sites specifically, but it does not
+  reach pure-C# code and adds asset-management overhead.
+
+---
+
+## Decision 2 — Timing: the bus retains, not the subscriber
+
+**Move replay into the bus so the subscriber has one code path.**
+
+Give each event a declared *delivery policy*:
+
+| Policy | Behavior | Fits |
+|---|---|---|
+| `Transient` (default) | Fire and forget. Current behavior. | Input, ticks, per-frame gameplay |
+| `Sticky` | Bus caches the last `(sender, data)`; a later subscriber receives it immediately on subscribe. | Lifecycle/state: `UnityServicesInitialized`, `PlayerAuthenticated`, `RemoteConfigUpdated`, `GameplayReady` |
+| `Replay` | Bus caches the ordered list and replays all of it. | Accumulations (`TrackSegmentCreated`), `EventHistory` |
+
+With `Sticky`, most of `UGS_State` and `GameState` evaporates. Instead of a
+subscription *plus* an `Awake`-time poll of a hand-maintained `bool`, a subscriber
+just subscribes — and if the event already fired, it is invoked immediately **with
+the original payload**. One code path, no mirror to drift, no lost data.
+
+### Declaring the policy
+
+On the enum member, read once at facade construction where `EventsPublisherEnums<T>`
+already reflects over `Enum.GetValues`. Zero per-publish cost:
+
+```csharp
+public enum UGS_EventsEnum
+{
+    [EventDelivery(Sticky)] UnityServicesInitialized,
+    [EventDelivery(Sticky)] PlayerAuthenticated,
+    [EventDelivery(Sticky)] RemoteConfigUpdated,
+    PlayerSigningIn,   // transient
+}
+```
+
+### Edge vs. level — the part that decides whether this works
+
+Sticky replay is correct for **level-triggered** state and wrong for
+**edge-triggered** transitions.
+
+The current enums are overwhelmingly edge-based — `MainMenuShowRequested` →
+`MainMenuShowing` → `MainMenuShown` → `MainMenuHiding` → `MainMenuHidden`. Replaying
+`MainMenuShown` to a late subscriber is meaningless; the menu may since have closed.
+This is precisely why the `bool` mirror emerged: the mirror is a hand-rolled *level*
+reconstructed from a pair of *edges*.
+
+So the per-event judgement is: **is this an edge or a level?**
+
+- Edges (`Xxxing` / `Xxxed` pairs, requests, one-shot notifications) → `Transient`.
+- Levels (`GameplayReady`, `IsGameConfigured`, `RemoteConfigUpdated`,
+  `DifficultyChanged`) → `Sticky`.
+
+Where a level is currently expressed as two opposing edges — `PlayerSignedIn` /
+`PlayerSignedOut`, `MainMenuShown` / `MainMenuHidden` — sticky alone is unsafe: a
+late subscriber after sign-out would still receive a stale "signed in". Two options,
+in order of preference:
+
+1. **Model the level directly**, carrying the value:
+   `AuthStateChanged(bool signedIn)`, `MainMenuVisibilityChanged(bool visible)`.
+   Sticky is then unambiguously correct, and the `bool` mirror is fully replaced.
+2. **Declare an invalidation pair** — `PlayerSignedOut` clears the sticky value of
+   `PlayerSignedIn`. Preserves the existing enums but keeps the two-edges-one-level
+   coupling that caused the drift.
+
+Option 1 is the real fix. Option 2 is the migration aid.
+
+### Reset scope
+
+A stale sticky value replaying into a fresh play session is a regression relative to
+today. The `IStackEventsPublisher` push/pop stack is the natural scope: a sticky
+value lives in the publisher frame it was published into, and `Pop()` discards it.
+`Clear()` must drop sticky state too, and `ClearEventsMenu`'s existing
+"clear on exiting play mode" toggle already covers the editor loop.
+
+### Replay re-entrancy
+
+A sticky replay fires during `SubscribeToEvent`, i.e. typically inside `Awake` —
+before `Start`, and possibly before other scene objects exist. This matches the
+timing of today's `Awake`-time poll, so it is consistent with existing behavior, but
+it must be documented: **a handler for a sticky event must tolerate being invoked
+during subscription.** Deferring replay to end-of-frame is the alternative; it is
+safer but changes ordering relative to the current poll and can itself be missed.
+
+### Independently: make the enum facades static
+
+`EventsPublisherEnumsSingleton<T> : MonoBehaviour` requires a GameObject in a scene,
+and that requirement is itself the source of the `[DefaultExecutionOrder(-10000)]`
+fragility described above. Nothing in `EventsPublisherEnums<T>` needs a scene
+object.
+
+A static, lazily-initialized `EventsFor<T>` removes the `Awake` race entirely, needs
+no execution-order attribute, and makes `EventsPublisherGameFlow`,
+`EventsPublisherUGS`, `EventsRegistration` and `GuiEventsPublisher` unnecessary.
+
+This is the single highest-value fix for the timing problem and is **independent of
+sticky events** — worth doing either way. It requires care around Unity's domain
+reload settings (`[RuntimeInitializeOnLoadMethod]` / `[InitializeOnEnterPlayMode]`)
+when *Enter Play Mode Options* has domain reload disabled.
+
+---
+
+## Consequences
+
+### Implemented in this change (Stage 0)
+
+Verified by compiling the package against Unity stubs and exercising old and new
+builds side by side. Claims below distinguish *fixed live defect* from *hardening*.
+
+`EventsPublisherInternal`:
+
+- **`DynamicInvoke` → direct cast invoke.** Removes a reflection dispatch and an
+  `object[]` allocation per callback per publish, and removes the
+  `TargetInvocationException` wrapping. This is the substantive win.
+- **Exception handler rewritten** to log the exception directly rather than
+  `e.InnerException.Message/StackTrace/Source`.
+  *Correction to an earlier draft of this ADR:* the old `InnerException` dereference
+  was **not** a live defect. `DynamicInvoke` wraps a throwing handler in
+  `TargetInvocationException`, so `InnerException` is non-null on the ordinary path;
+  a side-by-side probe confirmed the old code neither threw from the `catch` nor
+  left stale queue entries. The null-`InnerException` path required `DynamicInvoke`
+  itself to fail before invoking, which the typed API makes unreachable — every
+  queued callback is an `Action<string, object, object>` invoked with matching
+  arity. The rewrite is correctness-by-construction once the wrapping is gone, plus
+  a fuller log line; it is not a bug fix.
+- **Nested publishes enqueue and return** rather than starting a second drain of the
+  shared queue, with `try/finally` clearing the flag and the queue. Nested ordering
+  was verified **identical to the previous behavior** (`A1,A2,B1,B2` and
+  `A1,A2,B1,B2,C1` for a two-level nest), so this is not a behavioral change — it
+  makes the intent stated in the existing comment explicit rather than incidental,
+  and guarantees a callback that escapes cannot strand entries for a later publish.
+- **Null/empty event names are rejected** instead of reaching
+  `Dictionary.ContainsKey(null)`, which throws `ArgumentNullException` (confirmed
+  against the old build). Reachable via `FireEventAfterSceneLoads.OnDestroy`, which
+  unsubscribes `_resetOnEvent` unconditionally even when it is `null`. Note this is
+  latent for scene-authored components — Unity deserializes a null string field as
+  `""`, which the old code already tolerated — but live for components added at
+  runtime via `AddComponent`, where the `= null` initializer stands.
+
+`EventsPublisher`:
+
+- **Publishing an unregistered event name reports an error** in editor and
+  development builds, via `EventsPublisher.StrictMode`. Previously it skipped all
+  targeted callbacks while still notifying `allSubscribers` — so the logger printed
+  the event and the system looked healthy while no handler had run.
+  The check is deliberately at the **stack** level, not inside
+  `EventsPublisherInternal`: `RegisterEvent` registers only with the top frame while
+  `PublishEvent` visits every frame, so a per-frame check would report a false
+  positive on every lower frame once anything is pushed.
+
+`EventsPublisherEnums<T>` / `EventsPublisherEnumsSingleton<T>`:
+
+- Reports an error when two enum types project to the same `"TypeName/"` prefix.
+  Idempotent across Unity domain reloads: the same type re-claiming its own prefix
+  is not a collision.
+- Adds allocation-free `TryGetEnum(string, out T)` and `GetEventName(T)` so
+  consumers can stop slicing strings and calling `Enum.Parse` per publish.
+  `GameFlowAutoEventFlow`, `UGSAutoEventFlow` and `TempleRunAutoEventFlow` are the
+  intended first callers.
+
+No public API was removed or changed; all additions are additive, so 2.3.1
+consumers continue to compile.
+
+### Not addressed
+
+Stages 1–3 and Decision 2 are design only. No delivery policy is implemented.
+
+### Unrelated defects noticed
+
+Not fixed here; they are not identity or timing problems.
+
+- `EventsPublisherEnumsSingleton.Awake` destroys the *existing* `Instance` rather
+  than the duplicate (`Destroy(Instance)` where `Destroy(this)` is meant).
+  `GameState.Awake` and `UGS_State.Awake` have the same inversion via
+  `DestroyImmediate(Instance)`.
+- `EventsPublisherInternal.GetSubscribers` uses `.Skip(1)` on the invocation list,
+  assuming `NullCallback` is always first.
+
+---
+
+## Open questions
+
+1. **Delivery policy declaration** — attribute on the enum member, or an explicit
+   `RegisterEvent(name, policy)` overload? The attribute keeps the policy next to
+   the event; the overload allows runtime decisions and works for the
+   Inspector-authored string call sites.
+2. **Sticky replay timing** — immediate (consistent with today's `Awake` poll) or
+   end-of-frame (safer, but changes ordering)?
+3. **Edge→level migration** — model levels directly (Option 1) or ship invalidation
+   pairs (Option 2) to preserve the existing enums?
+4. **Inspector call sites** — these are what block Stage 1. A typed drop-down
+   (a `[EventName]` property drawer populated from `GetRegisteredEvents`, or
+   `ScriptableObject` channels) would fix them, but the existing baked strings in
+   `.unity`/`.prefab` need a migration path.
+5. **Static facade rollout** — does `RunnerUGSTemplate` run with domain reload
+   disabled? That determines how much static-state reset plumbing `EventsFor<T>`
+   needs.

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -461,13 +461,61 @@ Not fixed here; they are not identity or timing problems.
    unblocks Stage 1 and reopens `Type.FullName` (see *Rejected for now*).
 6. **`Replay` policy** — in scope. All three policies ship: `Transient`, `Sticky`,
    `Replay`.
+7. **Sticky reset granularity** — no `Invalidate(name)`. `Pop()` and `Clear()` are
+   the only reset mechanisms. Retained values are expected to stay valid across
+   scene boundaries, and the publisher stack provides the scoping where they should
+   not. See *Sticky reset granularity* below.
 
-## Sticky reset granularity — recommendation, pending confirmation
+## Sticky reset granularity — DECIDED: no `Invalidate`
 
-`Pop()` and `Clear()` are settled but coarse. The remaining question is whether a
-per-event `Invalidate(name)` is also needed.
+`Pop()` and `Clear()` are the only reset mechanisms. A per-event `Invalidate(name)`
+was considered and rejected. The analysis below is retained because it explains what
+the policy does *not* cover, and because two of its conclusions were wrong for this
+codebase in instructive ways.
 
-### The gap
+### Why it was rejected
+
+- **Retained values are expected to stay valid.** Most sticky state is cached
+  deliberately and remains correct across scene boundaries. Discarding it is the
+  unusual case, not the default.
+- **The stack already provides the scoping.** Where a value genuinely should not
+  outlive its scope, a publisher frame is the right unit, and `Pop()` discards it.
+- **The motivating example was mis-modelled.** Sign-out was used below as a case
+  where a level "becomes unknown". It is not: it is a value change, correctly
+  expressed as `AuthStateChanged(SignedOut)`. It is also read at exactly one point in
+  the flow — after the game ends and before the main menu is shown — so a stale
+  `RemoteConfigUpdated` between sign-out and re-authentication is never observed.
+  Re-authentication republishes it.
+
+### Retracted: auto-drop on a destroyed sender
+
+An earlier draft recommended that replay silently drop a retained value whose
+`sender` is a `UnityEngine.Object` comparing equal to null. **This is withdrawn — it
+would be actively harmful here.** A destroyed sender says nothing about whether the
+payload is still valid: `RemoteConfigUpdated` published by a manager that has since
+been destroyed still carries a perfectly good config. Silently dropping it would
+break precisely the "cached and can continue" case that is the norm.
+
+If a diagnostic is wanted at all, it should report rather than discard.
+
+### Where the retention concern actually lives
+
+The concern does not vanish; it moves, and it lands on `Replay` rather than `Sticky`:
+
+- The events that would be `Sticky` carry configs, enums and bools — `LevelConfig`,
+  `DifficultyConfig`, `bool`. These are assets or value types and survive scene
+  unload cleanly. This is why the leak argument below does not apply to them.
+- The events that would be `Replay` are the accumulating gameplay ones —
+  `TrackSegmentCreated`, `SplineSegmentCreated`. A full journal of those holds a
+  reference to **every segment ever created**, and unlike a sticky value it grows
+  without bound for the whole session rather than holding a single stale entry.
+
+`Replay` is therefore the policy that needs scoping, and the publisher stack is the
+mechanism: a gameplay scene that pushes a frame on load and pops it on unload
+discards its journal with the level. Implementation should not offer `Replay` without
+that scoping story.
+
+### The gap this leaves
 
 A sticky event has three possible states, and publishing only reaches two of them:
 
@@ -488,51 +536,19 @@ unknown*:
   a different and weaker claim than *"there is no current answer"* — and it forces
   every subscriber to null-check.
 
-The contracts differ at the subscriber: after `Invalidate`, a late subscriber is not
-invoked at all, exactly as if the event had never been published. After
-`Publish(null)`, it is invoked with null.
+The contracts differ at the subscriber: a value that was never published does not
+invoke the subscriber at all, whereas `Publish(null)` invokes it with null.
 
-The test is therefore: **is there a meaningful new value? If yes, publish. If the
-answer becomes "no answer", invalidate.**
+**Accepted consequence.** Without `Invalidate`, an event whose answer becomes
+"no answer" has only two ways to express it: leave the stale value retained, or
+publish an explicit unknown. The first is acceptable here because such values are
+either never read while stale, or are republished before they are. The second is
+preferred where a subscriber genuinely must distinguish — and it is not an
+invalidation at all but a state value, per the existing guidance to prefer an enum
+over `bool` wherever "not yet" is meaningful:
 
-### Why Unity makes this pressing rather than academic
+```csharp
+AuthStateChanged   // { Unknown, SignedOut, SigningIn, SignedIn }
+```
 
-Sticky retains `object sender` and `object data` indefinitely. `sender` is typically a
-`MonoBehaviour`, and `data` may be an arbitrary object graph rooted in the scene.
-
-When that scene unloads, the C++ object is destroyed but the managed wrapper stays
-alive as long as the sticky cache references it — the "fake null" state, where the
-reference is non-null to the CLR but `== null` under Unity's overloaded operator. Two
-consequences:
-
-- **Stale replay.** A subscriber in the *next* level receives a retained value
-  pointing at destroyed objects.
-- **Retention.** The wrapper itself is small, but the payload graph is not; a sticky
-  event can hold a whole level's worth of objects past unload.
-
-So some mechanism to drop retained values is required, not optional. `Invalidate` is
-the manual form.
-
-### Recommendation
-
-Adopt `Invalidate(name)`, scoped narrowly as **cache hygiene**:
-
-1. **Silent.** It drops the retained value and affects only future late subscribers.
-   It does not notify current subscribers.
-2. **Auto-drop a destroyed sender.** At replay time, if the retained sender is a
-   `UnityEngine.Object` that compares equal to null, drop the entry and do not
-   replay. This defends the common case without requiring discipline. It cannot
-   detect scene references inside `data`, so manual `Invalidate` on teardown is still
-   needed.
-3. **Consider per-scene frames.** `IStackEventsPublisher` already models scoping: if
-   an additive gameplay scene pushed a frame on load and popped it on unload, sticky
-   values published into it would be discarded automatically. Nothing pushes per
-   scene today — `Push()` is called once from the static constructor — so this is new
-   discipline rather than existing behavior, but it would make most manual
-   invalidation unnecessary.
-
-The scoping rule that keeps this from sprawling: **if subscribers need to react to
-the invalidation, it is not an invalidation — it is a state value.** Model it as an
-explicit "unknown" member of the level's value domain, per the existing guidance to
-prefer an enum over `bool` wherever "not yet" is meaningful. `Invalidate` exists only
-so that a late subscriber is not told something false.
+That covers the case `Invalidate` was proposed for, without a second mechanism.

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -694,10 +694,10 @@ consumers continue to compile.
 
 ### Tests
 
-`Tests/Editor` holds 80 EditMode tests across seven fixtures, covering dispatch ordering
+`Tests/Editor` holds 99 EditMode tests across nine fixtures, covering dispatch ordering
 and isolation, the static facade and its registration timing, all three delivery
-policies, the interned identity, the Inspector catalog and `EventRef`, and typed
-payloads. `Runtime/AssemblyInfo.cs` grants the test assembly access to internals so each
+policies, the interned identity, the Inspector catalog and `EventRef`, typed payloads,
+the late-delivery diagnostic, and the upgrade audit's reasoning. `Runtime/AssemblyInfo.cs` grants the test assembly access to internals so each
 test can reset `EventsRegistry`'s static state — a public reset would be a footgun in
 game code.
 
@@ -708,12 +708,15 @@ dropping the null-name guard; zero-based `EventId` handles; clearing the intern 
 reset; rebuilding a typed handler's wrapper at unsubscribe; skipping the publish-time and
 declaration-time payload checks; and delivering a mismatched payload anyway.
 
-Two mutations initially failed *nothing*, and both were treated as coverage gaps rather
+Three mutations initially failed *nothing*, and each was treated as a coverage gap rather
 than written off. Removing the unset-`EventRef` guard from the extension methods changed
 no behaviour, because the publisher already rejects null names — the code comment was
 corrected to say so rather than keep a claim no test supported. Accepting null for any
 payload type went unnoticed because no test subscribed a *value*-typed handler and sent
-it null; two tests were added, and the mutation now fails three.
+it null; two tests were added, and the mutation now fails three. Counting *every*
+subscribe as a late delivery went unnoticed because no test asserted that an early
+subscriber is not reported — the diagnostic's entire value rests on being quiet, since a
+report that flags every event is one nobody can act on.
 
 Consumers must add the package to `testables` in `Packages/manifest.json` for Unity to
 build them.

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -1,6 +1,7 @@
 # ADR 0001 — Event Identity and Delivery Timing
 
-**Status:** Decision 1 accepted, Stage 0 implemented. Decision 2 design agreed, unimplemented.
+**Status:** Decision 1 accepted, Stage 0 implemented. Decision 2 fully specified;
+`EventsFor<T>` implemented, delivery policy not yet.
 **Date:** 2026-08-12
 **Applies to:** `com.crawfissoftware.eventspublisher` 2.3.1 and consumers
 (`EventsPublishingTesting`, `RunnerUGSTemplate`)

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -694,7 +694,7 @@ consumers continue to compile.
 
 ### Tests
 
-`Tests/Editor` holds 99 EditMode tests across nine fixtures, covering dispatch ordering
+`Tests/Editor` holds 104 EditMode tests across nine fixtures, covering dispatch ordering
 and isolation, the static facade and its registration timing, all three delivery
 policies, the interned identity, the Inspector catalog and `EventRef`, typed payloads,
 the late-delivery diagnostic, and the upgrade audit's reasoning. `Runtime/AssemblyInfo.cs` grants the test assembly access to internals so each
@@ -720,6 +720,35 @@ report that flags every event is one nobody can act on.
 
 Consumers must add the package to `testables` in `Packages/manifest.json` for Unity to
 build them.
+
+#### The upgrade audit, run against a real project
+
+The audit's *gathering* step cannot be unit tested — it needs `TypeCache`, the asset
+database and a Unity project — so it was run end to end against `EndlessRunnerTemplate`,
+an unmigrated consumer, through a harness that substitutes only the type cache and reads
+everything else (asset YAML, `.cs` sources, the manifest) from the real project on disk.
+
+It found nothing. Every check reported *Ok* on a project that had taken none of the
+steps. Two separate causes:
+
+- **A real defect.** The `testables` check was a substring search over the whole
+  manifest, so it matched the package's own `dependencies` entry — which every consuming
+  project has. It could not have reported "not configured" for any project, ever, and
+  said the package was set up in a manifest with no `testables` key at all. Now scoped to
+  the `testables` array and covered by five tests, including the dependencies-only case
+  and a prefix collision that a later mutation showed was still open.
+- **A harness artifact.** `CollectSerializedStringFields` skips its own assembly, and the
+  probe had compiled the audit and the project's types together. Separating them, as
+  Unity does, was the fix — and it is the more faithful arrangement.
+
+Against the corrected build the audit finds the three event families and their three
+`[DefaultExecutionOrder(-10000)]` singletons, 50 serialized string fields of which 11 are
+event-name candidates, and the two event names actually baked into assets — verified
+against an independent grep of the project, which finds exactly those two.
+
+It also reports `EventHistory._events`, a `[TextArea]` log dump that is not an event name.
+That is the expected cost of the field-name heuristic, and is why asset-confirmed
+findings and name-based guesses are graded differently rather than presented as one list.
 
 ### Not addressed
 

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -1,6 +1,6 @@
 # ADR 0001 — Event Identity and Delivery Timing
 
-**Status:** Proposed
+**Status:** Decision 1 accepted, Stage 0 implemented. Decision 2 design agreed, unimplemented.
 **Date:** 2026-08-12
 **Applies to:** `com.crawfissoftware.eventspublisher` 2.3.1 and consumers
 (`EventsPublishingTesting`, `RunnerUGSTemplate`)
@@ -136,8 +136,10 @@ Stage 0 lands, whereas a wrong payload cast fails inside a handler.
   collision hole (two enums with the same simple name in different namespaces), but
   the projected names are serialized into `.unity` and `.prefab` assets. Changing
   the scheme would silently break every baked reference — the exact rename hazard
-  this ADR argues against. Stage 0 ships a collision *detector* instead. Revisit
-  alongside a scene-asset migration.
+  this ADR argues against. Stage 0 ships a collision *detector* instead.
+  **Reopened** — see Open Question 1. This rejection rests entirely on the baked
+  strings; if the scene objects move onto enums, `FullName` becomes viable and the
+  collision detector can be retired.
 - **Message-type-as-identity** (`readonly record struct GameStarted(int Score)`,
   MediatR/MessagePipe shape). The idiomatic C# endpoint: the CLR type is the
   identity, namespaces make collisions impossible, rename refactoring is safe, and
@@ -167,10 +169,49 @@ subscription *plus* an `Awake`-time poll of a hand-maintained `bool`, a subscrib
 just subscribes — and if the event already fired, it is invoked immediately **with
 the original payload**. One code path, no mirror to drift, no lost data.
 
-### Declaring the policy
+### Declaring the policy — DECIDED: hybrid, registered before any scene loads
 
-On the enum member, read once at facade construction where `EventsPublisherEnums<T>`
-already reflects over `Enum.GetValues`. Zero per-publish cost:
+Policy is declared through `RegisterEvent(name, policy)`, with an attribute sweep as
+the zero-timing default for enum families.
+
+The imperative form alone has three races, all silent:
+
+1. **Publish before register.** Nothing has declared `UnityServicesInitialized` as
+   `Sticky` yet, so the bus has no reason to retain it. The first publish — the one
+   that matters most during boot — is dropped. Precisely the case sticky exists for.
+2. **Subscribe before register.** `SubscribeToEvent` already calls `RegisterEvent`
+   internally, and `RegisterEvent` no-ops when the key exists. An early subscriber
+   therefore registers the event as `Transient`, and the later
+   `RegisterEvent(name, Sticky)` **silently does nothing**.
+3. **The publisher stack.** `RegisterEvent` goes to `Peek()`; `PublishEvent` visits
+   every frame. A `Push()` creates a frame that knows no policies.
+
+The resolution is not attribute-versus-imperative — it is getting registration off
+the `MonoBehaviour` lifecycle entirely.
+`[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]` runs
+after assemblies load and before the first scene's `Awake`, and therefore before
+every additively-loaded scene's `Awake` by definition. Races 1 and 2 disappear,
+because no user code can publish or subscribe before it.
+
+That constrains where the declaration can live: if registration must precede all user
+code, the policy must be knowable without running user code. An attribute is readable
+at type load and satisfies this for free; an imperative
+`Register(name, policy)` also satisfies it **provided the call site is a static
+initializer rather than an `Awake`**.
+
+Therefore:
+
+- **Enum families** — attribute on the member, swept at `BeforeSceneLoad`.
+  Zero timing, zero per-publish cost.
+- **`RegisterEvent(name, policy)`** — retained as the escape hatch for
+  runtime-computed names and any remaining Inspector-authored strings.
+- **Conflict rule** — first declaration wins; a differing later declaration is an
+  error, so an implicit registration cannot silently downgrade a declared policy.
+- **The policy registry is stack-global**, while the sticky *value cache* stays
+  per-frame so `Pop()` discards it. These are two different structures.
+- **Implicit registration is removed from `SubscribeToEvent`.** Once registration is
+  guaranteed at load, subscribing to an unregistered name is a typo rather than a
+  request to create one. This is the same change Stage 1 wants.
 
 ```csharp
 public enum UGS_EventsEnum
@@ -199,19 +240,62 @@ So the per-event judgement is: **is this an edge or a level?**
 - Levels (`GameplayReady`, `IsGameConfigured`, `RemoteConfigUpdated`,
   `DifficultyChanged`) → `Sticky`.
 
-Where a level is currently expressed as two opposing edges — `PlayerSignedIn` /
-`PlayerSignedOut`, `MainMenuShown` / `MainMenuHidden` — sticky alone is unsafe: a
-late subscriber after sign-out would still receive a stale "signed in". Two options,
-in order of preference:
+Where a level is currently expressed as two opposing edges — `GameplayReady` /
+`GameplayNotReady`, `PlayerSignedIn` / `PlayerSignedOut` — sticky alone is unsafe: a
+late subscriber after sign-out would still receive a stale "signed in".
 
-1. **Model the level directly**, carrying the value:
-   `AuthStateChanged(bool signedIn)`, `MainMenuVisibilityChanged(bool visible)`.
-   Sticky is then unambiguously correct, and the `bool` mirror is fully replaced.
-2. **Declare an invalidation pair** — `PlayerSignedOut` clears the sticky value of
-   `PlayerSignedIn`. Preserves the existing enums but keeps the two-edges-one-level
-   coupling that caused the drift.
+**DECIDED: model the level directly** (option 1 below), rather than declaring
+invalidation pairs (option 2), which would preserve the existing enums but keep the
+two-edges-one-level coupling that caused the drift in the first place.
 
-Option 1 is the real fix. Option 2 is the migration aid.
+#### What "model the level directly" means
+
+Make one event carry the state value, instead of two events announcing transitions
+into it:
+
+```csharp
+// Edge pair — needs history to interpret
+GameplayReady
+GameplayNotReady
+
+// Level — self-describing
+GameplayReadyChanged        // data: bool
+```
+
+The property that matters: **a level event is self-describing and idempotent.**
+Received once, late, with no history, it tells the whole truth — which is exactly
+what makes sticky replay safe. Replaying an *edge* is actively wrong: a late
+subscriber would get `GameplayReady` even though `GameplayNotReady` fired afterwards.
+
+| Current edge pair | Level event | Payload |
+|---|---|---|
+| `GameplayReady` / `GameplayNotReady` | `GameplayReadyChanged` | `bool` |
+| `PlayerSignedIn` / `PlayerSignedOut` | `AuthStateChanged` | `AuthState` enum |
+| `MainMenuShowing` / `MainMenuHidden` | `MainMenuVisibilityChanged` | `bool` |
+| `Paused` / `Resumed` | `PauseStateChanged` | `bool` |
+| `GameStarted` / `GameEnding` | `GameSessionStateChanged` | `{ NotStarted, Running, Ended }` |
+
+Several events are **already levels**: `RemoteConfigUpdated` carries the config,
+`DifficultyChanged` carries the difficulty, `GameConfigApplied` carries the config.
+These work with sticky unchanged. The tell is that they already carry a payload — an
+event that needs a payload to be useful is usually a level.
+
+Prefer an enum over `bool` wherever "not yet" is meaningful, since a never-published
+sticky event simply does not invoke the subscriber at all.
+
+#### The edges are not deleted
+
+This is additive, not a rewrite. Edges remain useful — `MainMenuHiding` is a real cue
+to start a fade, and animation, SFX and analytics all want the moment rather than the
+state. Both are kept, with different policies:
+
+- **Edges → `Transient`.** Anything reacting to the transition.
+- **Levels → `Sticky`.** Anything needing current state: late subscribers, UI
+  rebuilding itself, guards.
+
+Migration is therefore incremental: add the level event alongside the existing edges,
+publish it wherever the edges are published, move the `bool` pollers onto it, delete
+the `bool`.
 
 ### Reset scope
 
@@ -221,14 +305,40 @@ value lives in the publisher frame it was published into, and `Pop()` discards i
 `Clear()` must drop sticky state too, and `ClearEventsMenu`'s existing
 "clear on exiting play mode" toggle already covers the editor loop.
 
-### Replay re-entrancy
+### Replay timing — DECIDED: end of frame, paired with a synchronous pull
 
-A sticky replay fires during `SubscribeToEvent`, i.e. typically inside `Awake` —
-before `Start`, and possibly before other scene objects exist. This matches the
-timing of today's `Awake`-time poll, so it is consistent with existing behavior, but
-it must be documented: **a handler for a sticky event must tolerate being invoked
-during subscription.** Deferring replay to end-of-frame is the alternative; it is
-safer but changes ordering relative to the current poll and can itself be missed.
+Sticky replay is deferred to **end of frame** rather than fired inline during
+`SubscribeToEvent`. Inline replay would run a handler mid-`Awake`, before `Start` and
+possibly before other scene objects exist; end-of-frame avoids that re-entrancy
+entirely.
+
+This choice has a consequence that must be handled, or sticky will not actually
+retire the `bool` mirror. Today's pattern reads state **synchronously**:
+
+```csharp
+if (UGS_State.IsCheckForExistingSession) // Missed the event being published.
+```
+
+With end-of-frame replay, a component subscribing in `Awake` is not invoked until the
+end of that frame — so the value is still unavailable in `Start`. End-of-frame is
+strictly *later* than what the `bool` provides now, and on its own is a regression for
+this call site.
+
+Sticky is therefore paired with a synchronous pull alongside the push:
+
+```csharp
+bool TryGetLast(string eventName, out object sender, out object data);
+```
+
+- **Push** (end-of-frame replay) — the normal reactive path, no handler running
+  mid-`Awake`.
+- **Pull** (`TryGetLast`) — for code that genuinely needs the value during
+  `Awake`/`Start`.
+
+The pull path is a drop-in replacement for the `bool` check, except that it returns
+**the payload**, which a `bool` never could. The push/pull pair together is what
+retires the mirror; `TryGetLast` is required rather than optional given the
+end-of-frame decision.
 
 ### Independently: make the enum facades static
 
@@ -326,20 +436,45 @@ Not fixed here; they are not identity or timing problems.
 
 ---
 
+## Decisions taken
+
+1. **Delivery policy declaration** — hybrid. `RegisterEvent(name, policy)` is the
+   mechanism; an attribute sweep at `BeforeSceneLoad` is the zero-timing default for
+   enum families. First declaration wins, conflicts are an error, implicit
+   registration is removed from `SubscribeToEvent`. See *Declaring the policy*.
+2. **Sticky replay timing** — end of frame, paired with a synchronous
+   `TryGetLast` pull so `Awake`/`Start` code is not regressed. See *Replay timing*.
+3. **Edge→level migration** — model levels directly; do not ship invalidation pairs.
+   Edges are retained as `Transient` alongside the new `Sticky` levels. See
+   *Edge vs. level*.
+4. **Domain reload** — `RunnerUGSTemplate/ProjectSettings/EditorSettings.asset` has
+   `m_EnterPlayModeOptionsEnabled: 1` with `m_EnterPlayModeOptions: 0`, i.e. the
+   fast-enter feature is on but neither domain nor scene reload is actually disabled.
+   Statics therefore still reset on entering play mode today, so a static registry is
+   currently safe. The project is one checkbox away from statics persisting, so the
+   registry resets explicitly rather than relying on that.
+
 ## Open questions
 
-1. **Delivery policy declaration** — attribute on the enum member, or an explicit
-   `RegisterEvent(name, policy)` overload? The attribute keeps the policy next to
-   the event; the overload allows runtime decisions and works for the
-   Inspector-authored string call sites.
-2. **Sticky replay timing** — immediate (consistent with today's `Awake` poll) or
-   end-of-frame (safer, but changes ordering)?
-3. **Edge→level migration** — model levels directly (Option 1) or ship invalidation
-   pairs (Option 2) to preserve the existing enums?
-4. **Inspector call sites** — these are what block Stage 1. A typed drop-down
-   (a `[EventName]` property drawer populated from `GetRegisteredEvents`, or
-   `ScriptableObject` channels) would fix them, but the existing baked strings in
-   `.unity`/`.prefab` need a migration path.
-5. **Static facade rollout** — does `RunnerUGSTemplate` run with domain reload
-   disabled? That determines how much static-state reset plumbing `EventsFor<T>`
-   needs.
+1. **Inspector call sites.** These block Stage 1. The owner expects to be able to
+   move the scene-object strings onto enums without much difficulty; if so, three
+   consequences follow and should be confirmed before starting:
+   - Stage 1 (making the `string` API `internal`) becomes viable.
+   - The `Type.FullName` rejection above is **reopened** — that rejection rests
+     entirely on names being baked into `.unity`/`.prefab` assets. Remove the baked
+     strings and switching to `FullName` closes the namespace-collision hole for
+     free, at which point the Stage 0 collision detector can be retired.
+   - Beware the cross product. Unity cannot serialize `System.Enum` polymorphically,
+     so a per-family concrete subclass is needed for each generic component — eight
+     string-using components across four enum families is up to 32 classes if done
+     naively. A serializable `EventRef` (enum type name + member name, with a
+     two-dropdown property drawer) keeps one component per behavior, avoids typos,
+     and projects to the same event name. That is the same "string is a projection,
+     not the identity" principle applied to serialized data, and is likely the
+     better fit for Inspector fields specifically.
+2. **`Replay` policy** — is the full-journal variant wanted at all, or is
+   `Transient` + `Sticky` sufficient? `EventHistory` is the only obvious consumer,
+   and it already subscribes to all events.
+3. **Sticky reset granularity** — `Pop()` and `Clear()` are settled. Is a
+   per-event `Invalidate(name)` also needed for cases where a level becomes unknown
+   rather than changing value?

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -1,6 +1,6 @@
 # ADR 0001 — Event Identity and Delivery Timing
 
-**Status:** Decision 1 — Stages 0 and 2 implemented, Stage 1 revised, Stage 3 outstanding.
+**Status:** Decision 1 — Stages 0, 2 and 3 implemented, Stage 1 revised.
 Decision 2 implemented (`EventsFor<T>`, `Transient`/`Sticky`/`Replay`, immediate replay,
 `TryGetLast`).
 **Date:** 2026-08-12
@@ -181,14 +181,114 @@ The honest summary is that Stage 2's *safety* benefit had already been delivered
 `EventsFor<T>` and `EventRef`; what it adds is the identity being a real value type and
 one less dictionary hash on the hot path.
 
-**Stage 3 — type the payload.** `EventId<TData>`, with
-`Publish<TData>(EventId<TData> id, object sender, TData data)`. A wrong payload
-becomes a compile error rather than an `InvalidCastException` inside a swallowed
-callback. Erased subscribers still receive `object`, so the logger, `EventHistory`,
-and the editor menus do not change.
+**Stage 3 — type the payload. IMPLEMENTED.** `object data` was the larger of the two
+hazards: a typo'd key fails loudly once Stage 0 lands, whereas a wrong payload cast
+fails inside a handler, where `Drain` catches it and logs an exception naming neither
+the event's expected type nor who published it.
 
-`object data` is the larger hazard of the two — a typo'd key fails loudly once
-Stage 0 lands, whereas a wrong payload cast fails inside a handler.
+`EventId<TData>` is an `EventId` that also carries the payload type.
+`[EventPayload(typeof(X))]` declares that type on the enum member, next to
+`[EventDelivery]`, read once at facade construction.
+
+```csharp
+[EventEnum]
+public enum TempleRunEvents
+{
+    [EventPayload(typeof(PlayerFailedData))]
+    [EventDelivery(EventDelivery.Sticky)]
+    PlayerFailed,
+}
+
+private static readonly EventId<PlayerFailedData> Failed =
+    EventsFor<TempleRunEvents>.Id<PlayerFailedData>(TempleRunEvents.PlayerFailed);
+
+void OnEnable()  => Failed.Subscribe(OnPlayerFailed);
+void OnDisable() => Failed.Unsubscribe(OnPlayerFailed);
+
+private void OnPlayerFailed(string eventName, object sender, PlayerFailedData data) { }
+```
+
+#### What is a compile error, and what is not
+
+The claim this stage was written against — "a wrong payload becomes a compile error" —
+is true only downstream of one point, and the design is worth stating precisely.
+
+Once a call site holds an `EventId<TData>`, publishing the wrong payload and writing a
+handler with the wrong parameter type are both compile errors. There is no cast to get
+wrong, and no `object` in the handler signature to quietly accept anything.
+
+The exception is the place the type argument is *written*: `EventsFor<T>.Id<TData>` or
+`EventId<TData>.Of`. Nothing stops two call sites writing different type arguments for
+the same event, and no compiler can catch it, because each one is internally consistent.
+That single point is checked at runtime instead — the registry records the declared
+payload type, first declaration wins, and a differing one is an error naming both types.
+Declared in a `static readonly` field, that check runs once at type initialization.
+
+So the accurate statement is: **the type argument is written once and checked at
+startup; every use of it afterwards is checked by the compiler.**
+
+#### The check that earns its keep
+
+The residual hole is an *untyped* publish — a raw string, an Inspector-authored
+`EventRef`, or an enum through the erased overload — handing a typed subscriber
+something it cannot use. That is not hypothetical for a migrating project; it is most
+of RunnerUGSTemplate.
+
+Two things catch it, and the first matters more:
+
+- **At the publisher**, under `StrictMode`: the payload is tested against the
+  declaration and a mismatch names the event, the expected type, the actual type, and
+  **the sender**. One report per publish.
+- **At the wrapper** around each typed handler: the handler is skipped rather than
+  handed a value it cannot use, and the mismatch is reported. This fires even outside
+  `StrictMode`, but it cannot name the publisher — by then the sender is gone.
+
+Neither throws. A cast exception from inside a handler is already caught and logged by
+`Drain`; the only thing it adds over a plain error is a stack trace pointing at the
+handler, which is the one party not at fault.
+
+#### Erasure is preserved
+
+A typed publish reaches untyped subscribers of the same name, and an untyped publish
+reaches typed handlers. The typed API is a view onto the same event, not a parallel
+channel — if it were separate, every unmigrated subscriber would silently stop hearing
+migrated publishes. `SubscribeToAllEvents` still receives `object`, so the global
+logger, `EventHistory` and the editor menus see typed events without changing. Both
+directions are tested.
+
+#### Design notes
+
+- **No declaration means no checking.** An event with no `[EventPayload]` and no typed
+  identity behaves exactly as it did before this stage. Anything else would start
+  reporting every event in a project that has declared nothing.
+- **`typeof(object)` means "anything goes"**, declared explicitly rather than by
+  omission.
+- **Null is legal for a reference or nullable payload, and an error for a bare value
+  type.** Handing an `int` handler `default(int)` for a missing payload is the worst
+  outcome available — a missing score read as a real zero — so it is reported and the
+  handler skipped. The rule has one definition, `EventsRegistry.AcceptsNull`, called by
+  both the publish-time check and the wrapper. Two copies would eventually disagree
+  about whether a null is legal, and one would report what the other delivered.
+- **Typed handlers are wrapped, and the wrappers are remembered.** A typed
+  `Action<string, object, TData>` cannot be handed to the publisher directly, so it is
+  wrapped in an erased delegate. The wrapper is a new object each time it is built, so
+  rebuilding one at unsubscribe would hand `-=` a delegate matching nothing and leave
+  the handler subscribed forever. `TypedSubscriptions` keys them on
+  `(EventId, handler)` and reference-counts them, so subscribing twice fires twice and
+  takes two unsubscribes — the semantics untyped `+=` and `-=` already have. The table
+  is cleared on reset, or wrappers would leak across play sessions.
+- **`EventId<TData>` carries no operations.** Publish, subscribe, unsubscribe and
+  `TryGetLast` are extension methods, so the struct stays a pure identity with no
+  dependency on a particular publisher. Each has an overload taking an explicit
+  publisher for a pushed frame or an injected one.
+- **Nothing was added to `IEventsPublisher<T>`**, so no existing implementer changes.
+
+#### What this does not fix
+
+An event with no declared payload is still unchecked, and there is no way to require a
+declaration — adding one would break every existing event. The typed API is opt-in per
+event, which is what makes it adoptable incrementally, and also what leaves the
+undeclared majority exactly as hazardous as before.
 
 ### Rejected for now
 
@@ -594,22 +694,33 @@ consumers continue to compile.
 
 ### Tests
 
-`Tests/Editor` holds 31 EditMode tests across three fixtures, covering dispatch ordering
-and isolation, the static facade and its registration timing, and all three delivery
-policies. `Runtime/AssemblyInfo.cs` grants the test assembly access to internals so each
+`Tests/Editor` holds 80 EditMode tests across seven fixtures, covering dispatch ordering
+and isolation, the static facade and its registration timing, all three delivery
+policies, the interned identity, the Inspector catalog and `EventRef`, and typed
+payloads. `Runtime/AssemblyInfo.cs` grants the test assembly access to internals so each
 test can reset `EventsRegistry`'s static state — a public reset would be a footgun in
 game code.
 
-The suite was mutation-checked rather than merely observed green: retaining on every
-frame instead of the top one, firing sticky replay inline instead of through the queue,
-and dropping the null-name guard each fail exactly the test written for that behaviour.
+The suite is mutation-checked rather than merely observed green. Each of these was
+introduced deliberately and fails exactly the tests written for it: retaining on every
+frame instead of the top one; firing sticky replay inline instead of through the queue;
+dropping the null-name guard; zero-based `EventId` handles; clearing the intern table on
+reset; rebuilding a typed handler's wrapper at unsubscribe; skipping the publish-time and
+declaration-time payload checks; and delivering a mismatched payload anyway.
+
+Two mutations initially failed *nothing*, and both were treated as coverage gaps rather
+than written off. Removing the unset-`EventRef` guard from the extension methods changed
+no behaviour, because the publisher already rejects null names — the code comment was
+corrected to say so rather than keep a claim no test supported. Accepting null for any
+payload type went unnoticed because no test subscribed a *value*-typed handler and sent
+it null; two tests were added, and the mutation now fails three.
 
 Consumers must add the package to `testables` in `Packages/manifest.json` for Unity to
 build them.
 
 ### Not addressed
 
-Stages 1–3 and Decision 2 are design only. No delivery policy is implemented.
+Stage 1 is revised design only — see *Staged path*. Nothing else outstanding.
 
 ### Unrelated defects noticed
 
@@ -652,7 +763,17 @@ Not fixed here; they are not identity or timing problems.
    unblocks Stage 1 and reopens `Type.FullName` (see *Rejected for now*).
 6. **`Replay` policy** — in scope. All three policies ship: `Transient`, `Sticky`,
    `Replay`.
-7. **Sticky reset granularity** — no `Invalidate(name)`. `Pop()` and `Clear()` are
+7. **Typed payloads are opt-in, per event.** `[EventPayload(typeof(X))]` declares the
+   type; an event without one stays unchecked. Requiring a declaration would break
+   every existing event, and defaulting undeclared events to "carries nothing" would
+   report most of a real project on day one. The cost is that the undeclared majority
+   is exactly as hazardous as before, which is accepted so that migration can be
+   incremental. See *Stage 3*.
+8. **A payload mismatch is reported, not thrown.** `Drain` already catches and logs
+   whatever a handler throws, so throwing would add only a stack trace pointing at the
+   handler — the one party not at fault. The publish-time report names the sender
+   instead, which is the part needed to find the bug. See *Stage 3*.
+9. **Sticky reset granularity** — no `Invalidate(name)`. `Pop()` and `Clear()` are
    the only reset mechanisms. Retained values are expected to stay valid across
    scene boundaries, and the publisher stack provides the scoping where they should
    not. See *Sticky reset granularity* below.

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -1,7 +1,8 @@
 # ADR 0001 — Event Identity and Delivery Timing
 
-**Status:** Decision 1 accepted, Stage 0 implemented. Decision 2 implemented
-(`EventsFor<T>`, `Transient`/`Sticky`/`Replay`, immediate replay, `TryGetLast`).
+**Status:** Decision 1 — Stages 0 and 2 implemented, Stage 1 revised, Stage 3 outstanding.
+Decision 2 implemented (`EventsFor<T>`, `Transient`/`Sticky`/`Replay`, immediate replay,
+`TryGetLast`).
 **Date:** 2026-08-12
 **Applies to:** `com.crawfissoftware.eventspublisher` 2.3.1 and consumers
 (`EventsPublishingTesting`, `RunnerUGSTemplate`)
@@ -135,19 +136,50 @@ Removing implicit registration from `SubscribeToEvent` — the one piece of the 
 Stage 1 still worth doing — is deferred until the Inspector call sites have moved to
 `EventRef`, since it would break subscribing to a name that is not pre-registered.
 
-**Stage 2 — `EventId` as identity.**
+**Stage 2 — `EventId` as identity.** *(Implemented.)*
 
 ```csharp
 public readonly struct EventId : IEquatable<EventId>
 {
-    private readonly int _id;                    // interned; dictionary key
-    public string Name => EventNames.Get(_id);   // projection — observers only
+    private readonly int _handle;                        // interned; one-based
+    public string Name => EventsRegistry.GetInternedName(this);   // projection
 }
 ```
 
-`EventsPublisherEnums<T>` becomes the interner rather than a string factory, so the
-enum authoring surface is unchanged. The internal dictionary keys on `int`: no
-string hashing, no collisions, no allocation.
+The publisher's per-event dictionaries — subscribers, sticky values, `Replay` journals —
+are keyed on `EventId`. Callbacks are unchanged: a handler still receives
+`(string eventName, object sender, object data)`, resolved off the id. That is what
+kept this from breaking every subscriber in `RunnerUGSTemplate`.
+
+`EventId` entry points live on a separate `IEventIdPublisher` rather than on
+`IEventsPublisher<T>`, so adding them breaks no implementer. `EventsPublisherEnums<T>`
+resolves each member's id once at construction and takes the id path when the injected
+publisher supports it, falling back to the name path when it does not.
+
+Two invariants carry weight, and both are pinned by tests that fail broadly when broken:
+
+- **Handles are one-based**, so `default(EventId)` is invalid rather than aliasing the
+  first interned event.
+- **The intern table survives `ResetStaticState`.** Handles are values a caller may
+  still hold; recycling them would silently repoint an `EventId` at a different event.
+  The table is bounded by the number of distinct event names in the project.
+
+#### Which of this stage's original claims held
+
+Stated as "no string hashing, no collisions, no allocation". Only the first survived:
+
+- **No string hashing** — delivered, on the enum path. `EventsFor<T>` resolves ids at
+  construction, so publishing never hashes a name again. The raw-string entry points
+  still hash once to resolve, which is unavoidable and correct.
+- **No collisions** — wrong. Interning does not prevent two enums projecting onto the
+  same name; identical names intern to the *same* id, which is the collision, not a
+  fix for it. `[EventEnum(Prefix = "...")]` is what addresses that.
+- **No allocation** — already true before this stage. Names were pre-projected and
+  cached at facade construction, so publishing allocated nothing to begin with.
+
+The honest summary is that Stage 2's *safety* benefit had already been delivered by
+`EventsFor<T>` and `EventRef`; what it adds is the identity being a real value type and
+one less dictionary hash on the hot path.
 
 **Stage 3 — type the payload.** `EventId<TData>`, with
 `Publish<TData>(EventId<TData> id, object sender, TData data)`. A wrong payload

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -533,6 +533,21 @@ builds side by side. Claims below distinguish *fixed live defect* from *hardenin
 No public API was removed or changed; all additions are additive, so 2.3.1
 consumers continue to compile.
 
+### Tests
+
+`Tests/Editor` holds 31 EditMode tests across three fixtures, covering dispatch ordering
+and isolation, the static facade and its registration timing, and all three delivery
+policies. `Runtime/AssemblyInfo.cs` grants the test assembly access to internals so each
+test can reset `EventsRegistry`'s static state — a public reset would be a footgun in
+game code.
+
+The suite was mutation-checked rather than merely observed green: retaining on every
+frame instead of the top one, firing sticky replay inline instead of through the queue,
+and dropping the null-name guard each fail exactly the test written for that behaviour.
+
+Consumers must add the package to `testables` in `Packages/manifest.json` for Unity to
+build them.
+
 ### Not addressed
 
 Stages 1–3 and Decision 2 are design only. No delivery policy is implemented.

--- a/Documentation~/upgrade-prompt.md
+++ b/Documentation~/upgrade-prompt.md
@@ -55,7 +55,14 @@ Steps 1-5 are mechanical. Do them without asking, one commit each.
     then delete the subclasses and their [DefaultExecutionOrder] attributes. That
     attribute only orders Awake within one scene load batch, so it never protected
     additively-loaded scenes anyway. The old singleton forwards to the same facade, so
-    this can be done file by file.
+    the call sites can move file by file.
+      This is the one step that is NOT code-only. A singleton subclass is a MonoBehaviour,
+    so deleting it orphans every instance authored into a scene — the project ends up with
+    missing-script entries where a working singleton used to be. Find them by the
+    subclass's script GUID, show me the list, and remove them. Where the component sits on
+    a GameObject that hosts nothing else, the GameObject goes too; unlink its transform
+    from the scene roots or from its parent's m_Children, and confirm nothing still
+    references what you removed.
  5. Replace any per-publish Enum.Parse in "all events" handlers with
     EventsFor<T>.TryGetEnum(name, out var value).
 
@@ -74,6 +81,12 @@ Steps 6 and 7 need judgement. Propose, then wait for me.
     last. Propose a single level event carrying the value instead, and keep the edges as
     Transient for animation, SFX and analytics. Prefer an enum over bool wherever "not
     yet" is a meaningful third state.
+      Before marking anything Sticky, check whether it is the SOURCE of an auto-chain or a
+    bridge mapping. A retained event is redelivered to anything that subscribes late
+    through SubscribeToAll, so the whole chain re-fires from that point. Sometimes that is
+    exactly the fix — a bridge in an additively-loaded scene that was silently missing the
+    event now receives it — and sometimes it is a duplicate scene load or a re-run command.
+    Read the project's auto-flow and bridge maps and tell me which one you think it is.
       Only after a level event is in place and subscribed to, delete the corresponding
     static bool mirror and its Awake-time poll.
  7. Payload types. Add [EventPayload(typeof(X))] to events that carry data, and convert
@@ -106,7 +119,10 @@ Steps 6 and 7 need judgement. Propose, then wait for me.
 
 ## What not to do
 
- - Do not auto-rewrite scenes or prefabs. Every step here is a code or attribute change.
+ - Do not auto-rewrite scenes or prefabs. The single exception is removing the orphaned
+   publisher-singleton components in step 4, which is not optional — the step is unfinished
+   without it. Enumerate those by script GUID, show me the list before touching anything,
+   and leave alone any GameObject that carries something else.
  - Do not convert string fields to EventRef (see step 3).
  - Do not mark an event Sticky because its name sounds like a state. Use the runtime
    evidence, and when the evidence is absent say so rather than guessing.

--- a/Documentation~/upgrade-prompt.md
+++ b/Documentation~/upgrade-prompt.md
@@ -1,0 +1,116 @@
+# Upgrade prompt
+
+Drop this into an AI coding assistant working in a project that consumes
+EventsPublisher. It is deliberately project-agnostic: it tells the assistant how to
+*discover* the project's call sites rather than naming them, so the same text works in
+every consuming project.
+
+Paste the **Copy report** output from **Window > Events > Upgrade Audit** underneath it
+when you have one. Without a report the assistant has to rediscover by hand what the
+audit already knows.
+
+---
+
+```
+Upgrade this project to EventsPublisher 2.4.
+
+Read Documentation~/UPGRADING.md in the package first — it is the operational guide, and
+Documentation~/adr/0001-event-identity-and-delivery.md has the reasoning behind each
+step, including the places the design's own earlier claims turned out to be wrong.
+
+Nothing in this upgrade is required. The package is source-compatible, so a project that
+changes nothing keeps working. Every step is opt-in and independently shippable. Do not
+treat a step as mandatory because it is listed.
+
+## How to find the work
+
+Do not guess at this project's structure. Run Window > Events > Upgrade Audit and work
+its findings. If an audit report is pasted below, start from it. If not, ask me to run
+the audit and paste the report before doing anything in steps 3 or 6 — those two depend
+on evidence the audit gathers and are guesswork without it.
+
+Findings are graded, and the grades mean something:
+ - Action     — discovered from evidence; safe to just do.
+ - Suggestion — a guess or a judgement the tool cannot make. Bring it to me, do not
+                silently act on it.
+ - Ok         — already done; skip it.
+
+## Order of work
+
+Steps 1-5 are mechanical. Do them without asking, one commit each.
+
+ 1. Add the package to "testables" in Packages/manifest.json. Then ask me to run the
+    EditMode tests and confirm they pass before you continue — they were verified on a
+    stub harness, not in a real editor.
+ 2. Add [EventEnum] to every event enum the audit lists as unmarked. If a prefix
+    collision is reported, fix it with [EventEnum(Prefix = "...")] on ONE of the
+    colliding enums. Never rename an enum type and never switch to Type.FullName.
+ 3. Add [EventName] to the serialized string fields the audit lists. Add the ATTRIBUTE
+    only — do not change any field's type to EventRef. Changing the type changes the
+    serialized shape, so Unity cannot carry the value across and every event name already
+    baked into a .unity or .prefab is lost. EventRef is for new fields.
+      Audit entries annotated "(holds an event name in an asset)" are certain. The rest
+    are name-based guesses — list them for me rather than assuming.
+ 4. Replace EventsPublisherEnumsSingleton<T> subclasses with the static EventsFor<T>,
+    then delete the subclasses and their [DefaultExecutionOrder] attributes. That
+    attribute only orders Awake within one scene load batch, so it never protected
+    additively-loaded scenes anyway. The old singleton forwards to the same facade, so
+    this can be done file by file.
+ 5. Replace any per-publish Enum.Parse in "all events" handlers with
+    EventsFor<T>.TryGetEnum(name, out var value).
+
+Steps 6 and 7 need judgement. Propose, then wait for me.
+
+ 6. Delivery policy. Ask me to enter play mode, run the boot sequence, and refresh the
+    audit. The report then lists every event whose subscribers arrived after it was
+    published — these are the Sticky candidates, measured rather than guessed.
+      For each, decide edge or level and TELL ME YOUR REASONING before changing
+    anything. An edge is a transition, only meaningful in sequence — leave it Transient,
+    because replaying an edge is actively wrong. A level is a state, self-describing on
+    its own — mark it [EventDelivery(EventDelivery.Sticky)]. An event that already
+    carries a payload is usually a level.
+      Where a level is currently two opposing edges (Ready/NotReady, SignedIn/SignedOut,
+    Paused/Resumed), sticky alone is unsafe — a late subscriber gets whichever half fired
+    last. Propose a single level event carrying the value instead, and keep the edges as
+    Transient for animation, SFX and analytics. Prefer an enum over bool wherever "not
+    yet" is a meaningful third state.
+      Only after a level event is in place and subscribed to, delete the corresponding
+    static bool mirror and its Awake-time poll.
+ 7. Payload types. Add [EventPayload(typeof(X))] to events that carry data, and convert
+    their call sites to a static readonly EventId<X> resolved once via
+    EventsFor<T>.Id<X>(member). Start with events that ALREADY carry a payload — they
+    have a real type to declare and the most casts to delete. Leave events with no
+    payload, or a genuinely variable one, unannotated; no declaration means no checking,
+    which is the intended default.
+      Do not try to type the Inspector-authored components from step 3. They hold their
+    event name as data, so there is no type argument to write. StrictMode reports their
+    payload mismatches at the publisher instead.
+
+## Rules that hold throughout
+
+ - NEVER rename an event that has already been published. Names are serialized into
+   scenes and prefabs; renaming silently breaks every baked reference. Everything here
+   is additive.
+ - Keep EventsPublisher.StrictMode on for the whole migration. It reports both an
+   unregistered name and a mismatched payload, which is how mistakes in steps 2, 3 and 7
+   surface.
+ - Erasure holds in both directions, so nothing needs to move in lockstep: typed
+   publishes reach untyped subscribers, untyped publishes reach typed handlers, and
+   SubscribeToAllEvents still receives object. Loggers, event history and editor menus
+   need no change at any point.
+ - You do not need to do anything for EventId. The publisher keys on an interned handle
+   internally and handler signatures did not change.
+ - After each step, ask me to enter play mode and confirm the boot sequence still
+   completes, watching the console for StrictMode errors. Do not batch several steps and
+   verify once.
+
+## What not to do
+
+ - Do not auto-rewrite scenes or prefabs. Every step here is a code or attribute change.
+ - Do not convert string fields to EventRef (see step 3).
+ - Do not mark an event Sticky because its name sounds like a state. Use the runtime
+   evidence, and when the evidence is absent say so rather than guessing.
+ - Do not add [EventPayload] to an event whose payload actually varies by publisher.
+   Declaring typeof(object) is the honest way to say "anything goes".
+ - Do not report a step as done without saying what you verified.
+```

--- a/Editor/AssemblyInfo.cs
+++ b/Editor/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// The catalog and the popup's option builder are internal but carry real logic — the projection that
+// must match the runtime one, and the rule that an unrecognised value is surfaced rather than cleared.
+[assembly: InternalsVisibleTo("CrawfisSoftware.EventsPublisher.Tests")]

--- a/Editor/AssemblyInfo.cs.meta
+++ b/Editor/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53e71dfb56964e7ea68c51b07965ba5a

--- a/Editor/EventNameCatalog.cs
+++ b/Editor/EventNameCatalog.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEditor;
+
+namespace CrawfisSoftware.Events.Editor
+{
+    /// <summary>
+    /// The set of event names offered by the Inspector dropdowns, projected from every enum marked
+    /// <see cref="EventEnumAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>The names must match what <see cref="EventsPublisherEnums{T}"/> projects at runtime, since
+    /// the chosen string is what the publisher is keyed on. The projection is duplicated here rather
+    /// than shared because the runtime one lives behind a generic type parameter this editor code does
+    /// not have; <see cref="EventNameCatalogTests"/> pins the two together.</para>
+    /// <para>Marking an enum <see cref="EventEnumAttribute"/> is the opt-in. An enum with no attribute
+    /// contributes nothing, and a serialized value naming one of its members is treated as unknown —
+    /// shown as missing, never silently cleared.</para>
+    /// </remarks>
+    internal static class EventNameCatalog
+    {
+        private static string[] _cached;
+
+        /// <summary>All known event names, sorted, in <c>"TypeName/MemberName"</c> form.</summary>
+        internal static string[] Names
+        {
+            get
+            {
+                if (_cached == null)
+                {
+                    // TypeCache is maintained by the editor and is far cheaper than walking assemblies.
+                    var enumTypes = new List<Type>(TypeCache.GetTypesWithAttribute<EventEnumAttribute>());
+                    _cached = BuildNames(enumTypes);
+                }
+                return _cached;
+            }
+        }
+
+        /// <summary>Drops the cache so the next access rebuilds it, after a domain reload or recompile.</summary>
+        [InitializeOnLoadMethod]
+        internal static void Invalidate()
+        {
+            _cached = null;
+        }
+
+        /// <summary>
+        /// Projects a set of enum types onto sorted event names. Kept free of editor APIs so it can be
+        /// tested directly.
+        /// </summary>
+        internal static string[] BuildNames(IEnumerable<Type> enumTypes)
+        {
+            var names = new List<string>();
+            if (enumTypes != null)
+            {
+                foreach (Type enumType in enumTypes)
+                {
+                    if (enumType == null || !enumType.IsEnum) continue;
+                    string prefix = enumType.Name;
+                    foreach (object value in Enum.GetValues(enumType))
+                    {
+                        string candidate = prefix + "/" + value;
+                        // Enum members sharing a value collapse to one name; do not offer duplicates.
+                        if (!names.Contains(candidate)) names.Add(candidate);
+                    }
+                }
+            }
+            names.Sort(StringComparer.Ordinal);
+            return names.ToArray();
+        }
+    }
+}

--- a/Editor/EventNameCatalog.cs
+++ b/Editor/EventNameCatalog.cs
@@ -11,9 +11,9 @@ namespace CrawfisSoftware.Events.Editor
     /// </summary>
     /// <remarks>
     /// <para>The names must match what <see cref="EventsPublisherEnums{T}"/> projects at runtime, since
-    /// the chosen string is what the publisher is keyed on. The projection is duplicated here rather
-    /// than shared because the runtime one lives behind a generic type parameter this editor code does
-    /// not have; <see cref="EventNameCatalogTests"/> pins the two together.</para>
+    /// the chosen string is what the publisher is keyed on. Both call
+    /// <see cref="EventsRegistry.GetPrefix"/>, so there is one definition of the projection rather than
+    /// two that could drift; <see cref="EventNameCatalogTests"/> pins them together regardless.</para>
     /// <para>Marking an enum <see cref="EventEnumAttribute"/> is the opt-in. An enum with no attribute
     /// contributes nothing, and a serialized value naming one of its members is treated as unknown —
     /// shown as missing, never silently cleared.</para>
@@ -56,7 +56,7 @@ namespace CrawfisSoftware.Events.Editor
                 foreach (Type enumType in enumTypes)
                 {
                     if (enumType == null || !enumType.IsEnum) continue;
-                    string prefix = enumType.Name;
+                    string prefix = EventsRegistry.GetPrefix(enumType);
                     foreach (object value in Enum.GetValues(enumType))
                     {
                         string candidate = prefix + "/" + value;

--- a/Editor/EventNameCatalog.cs.meta
+++ b/Editor/EventNameCatalog.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a7a361115c734fdf994bdf8dfe9e8fcd

--- a/Editor/EventNameDrawers.cs
+++ b/Editor/EventNameDrawers.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+
+using UnityEditor;
+
+using UnityEngine;
+
+namespace CrawfisSoftware.Events.Editor
+{
+    /// <summary>
+    /// Renders an event-name string as a dropdown of known events.
+    /// </summary>
+    /// <remarks>Shared by <see cref="EventNameDrawer"/> and <see cref="EventRefDrawer"/>, which differ
+    /// only in where the string lives.</remarks>
+    internal static class EventNamePopup
+    {
+        private const string NoneLabel = "<none>";
+
+        /// <summary>
+        /// Draws the dropdown for a string property, writing back only when the user picks something.
+        /// </summary>
+        internal static void Draw(Rect position, SerializedProperty stringProperty, GUIContent label)
+        {
+            if (stringProperty == null || stringProperty.propertyType != SerializedPropertyType.String)
+            {
+                EditorGUI.LabelField(position, label.text, "Use [EventName] on a string field.");
+                return;
+            }
+
+            string current = stringProperty.stringValue;
+            string[] options = BuildOptions(EventNameCatalog.Names, current, out int selected);
+
+            var contents = new GUIContent[options.Length];
+            for (int i = 0; i < options.Length; i++)
+            {
+                // Unity renders '/' in popup entries as nested submenus, which groups the list by enum
+                // family without needing a second control.
+                contents[i] = new GUIContent(options[i]);
+            }
+
+            EditorGUI.BeginProperty(position, label, stringProperty);
+            int picked = EditorGUI.Popup(position, label, selected, contents);
+            EditorGUI.EndProperty();
+
+            // Only write on an actual change. Re-writing the current value would dirty every scene the
+            // Inspector merely displayed, and would destroy an unrecognised value on first paint.
+            if (picked != selected)
+            {
+                stringProperty.stringValue = picked == 0 ? string.Empty : options[picked];
+            }
+        }
+
+        /// <summary>
+        /// Builds the option list and resolves which entry the current value corresponds to.
+        /// </summary>
+        /// <remarks>An unrecognised non-empty value gets its own entry and is selected, so a name whose
+        /// enum is not marked <see cref="EventEnumAttribute"/> — or has since been renamed — is surfaced
+        /// rather than silently replaced with the first alphabetical event.</remarks>
+        internal static string[] BuildOptions(string[] known, string current, out int selectedIndex)
+        {
+            var options = new List<string> { NoneLabel };
+            options.AddRange(known ?? Array.Empty<string>());
+
+            if (string.IsNullOrEmpty(current))
+            {
+                selectedIndex = 0;
+                return options.ToArray();
+            }
+
+            int index = options.IndexOf(current);
+            if (index >= 0)
+            {
+                selectedIndex = index;
+                return options.ToArray();
+            }
+
+            options.Add("Missing/" + current);
+            selectedIndex = options.Count - 1;
+            return options.ToArray();
+        }
+    }
+
+    /// <summary>Dropdown for a <see cref="string"/> field marked <see cref="EventNameAttribute"/>.</summary>
+    [CustomPropertyDrawer(typeof(EventNameAttribute))]
+    internal sealed class EventNameDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EventNamePopup.Draw(position, property, label);
+        }
+    }
+
+    /// <summary>Dropdown for an <see cref="EventRef"/> field.</summary>
+    [CustomPropertyDrawer(typeof(EventRef))]
+    internal sealed class EventRefDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EventNamePopup.Draw(position, property.FindPropertyRelative("_eventName"), label);
+        }
+    }
+}

--- a/Editor/EventNameDrawers.cs.meta
+++ b/Editor/EventNameDrawers.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 65db5dd2ea8d4181b4e0fc2b4a15f9e5

--- a/Editor/EventsUpgradeAudit.cs
+++ b/Editor/EventsUpgradeAudit.cs
@@ -190,7 +190,7 @@ namespace CrawfisSoftware.Events.Editor
             foreach (Type type in input.SingletonSubclasses)
             {
                 if (type == null) continue;
-                bool ordered = type.IsDefined(typeof(UnityEngine.DefaultExecutionOrderAttribute), false);
+                bool ordered = type.IsDefined(typeof(UnityEngine.DefaultExecutionOrder), false);
                 details.Add(type.FullName + (ordered ? "  [DefaultExecutionOrder]" : ""));
             }
 

--- a/Editor/EventsUpgradeAudit.cs
+++ b/Editor/EventsUpgradeAudit.cs
@@ -108,6 +108,27 @@ namespace CrawfisSoftware.Events.Editor
             "Selected", "Changed", "Available", "Complete", "Completed", "Enabled", "Connected",
         };
 
+        /// <summary>
+        /// Whether a <c>manifest.json</c> lists a package in its <c>testables</c> array.
+        /// </summary>
+        /// <remarks>Scoped to the <c>testables</c> array specifically. A plain substring search over the
+        /// whole manifest matches the package's own <c>dependencies</c> entry, which is always present —
+        /// so it would report every project as already configured and never once be right.</remarks>
+        public static bool IsListedInTestables(string manifestJson, string packageName)
+        {
+            if (string.IsNullOrEmpty(manifestJson) || string.IsNullOrEmpty(packageName)) return false;
+
+            int key = manifestJson.IndexOf("\"testables\"", StringComparison.Ordinal);
+            if (key < 0) return false;
+            int open = manifestJson.IndexOf('[', key);
+            if (open < 0) return false;
+            int close = manifestJson.IndexOf(']', open);
+            if (close < 0) return false;
+
+            return manifestJson.Substring(open, close - open)
+                               .IndexOf("\"" + packageName + "\"", StringComparison.Ordinal) >= 0;
+        }
+
         /// <summary>Runs every check and returns the findings, most urgent first.</summary>
         public static List<UpgradeFinding> Analyze(UpgradeAuditInput input)
         {

--- a/Editor/EventsUpgradeAudit.cs
+++ b/Editor/EventsUpgradeAudit.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace CrawfisSoftware.Events.Editor
+{
+    /// <summary>How much attention a finding needs.</summary>
+    public enum UpgradeSeverity
+    {
+        /// <summary>Nothing to do.</summary>
+        Ok = 0,
+
+        /// <summary>Worth looking at, but needs a judgement this tool cannot make.</summary>
+        Suggestion = 1,
+
+        /// <summary>A concrete, mechanical step that has not been taken.</summary>
+        Action = 2,
+    }
+
+    /// <summary>One thing the audit noticed.</summary>
+    public readonly struct UpgradeFinding
+    {
+        /// <summary>Which migration step this belongs to.</summary>
+        public readonly string Step;
+
+        public readonly UpgradeSeverity Severity;
+
+        /// <summary>One line, suitable for a list.</summary>
+        public readonly string Summary;
+
+        /// <summary>The specifics — type names, field names, counts. May be empty.</summary>
+        public readonly IReadOnlyList<string> Details;
+
+        public UpgradeFinding(string step, UpgradeSeverity severity, string summary, IReadOnlyList<string> details = null)
+        {
+            Step = step;
+            Severity = severity;
+            Summary = summary;
+            Details = details ?? Array.Empty<string>();
+        }
+    }
+
+    /// <summary>A string found in a scene, prefab or asset whose value is a known event name.</summary>
+    public readonly struct SerializedEventName
+    {
+        /// <summary>Asset path the value was found in.</summary>
+        public readonly string AssetPath;
+
+        /// <summary>The serialized field key, as it appears in the YAML.</summary>
+        public readonly string FieldName;
+
+        /// <summary>The event name held in that field.</summary>
+        public readonly string Value;
+
+        public SerializedEventName(string assetPath, string fieldName, string value)
+        {
+            AssetPath = assetPath;
+            FieldName = fieldName;
+            Value = value;
+        }
+    }
+
+    /// <summary>
+    /// Everything the audit reasons about, gathered separately so the analysis can be tested without an
+    /// editor, a project, or an asset database.
+    /// </summary>
+    public sealed class UpgradeAuditInput
+    {
+        /// <summary>Enum types reachable as event families, however they were discovered.</summary>
+        public IReadOnlyList<Type> EventEnums = Array.Empty<Type>();
+
+        /// <summary>Concrete subclasses of <c>EventsPublisherEnumsSingleton&lt;T&gt;</c>.</summary>
+        public IReadOnlyList<Type> SingletonSubclasses = Array.Empty<Type>();
+
+        /// <summary>Serialized <c>string</c> fields on components, with their declaring type.</summary>
+        public IReadOnlyList<FieldInfo> SerializedStringFields = Array.Empty<FieldInfo>();
+
+        /// <summary>Event names found inside scene, prefab and asset files.</summary>
+        public IReadOnlyList<SerializedEventName> SerializedEventNames = Array.Empty<SerializedEventName>();
+
+        /// <summary>Whether the package is listed in the project's <c>testables</c>.</summary>
+        public bool TestablesConfigured;
+
+        /// <summary>What the runtime diagnostic recorded, if a play session has run.</summary>
+        public IReadOnlyList<EventsDiagnostics.Observation> LateDeliveries = Array.Empty<EventsDiagnostics.Observation>();
+
+        /// <summary>False when no play session has run since the last reset, so silence means nothing.</summary>
+        public bool DiagnosticsHaveData;
+    }
+
+    /// <summary>
+    /// Reports which upgrade steps a project has and has not taken.
+    /// </summary>
+    /// <remarks>
+    /// <para>Written for the several projects consuming this package, none of which this tool knows
+    /// anything about. Everything here is discovered by reflection and by reading the project's own
+    /// assets, so the same audit works unchanged in a project it has never seen.</para>
+    /// <para>The analysis is deliberately separate from both the gathering and the window. Gathering
+    /// needs <c>TypeCache</c> and the asset database; the window needs IMGUI; the reasoning needs
+    /// neither, and is the only part worth testing.</para>
+    /// </remarks>
+    public static class EventsUpgradeAudit
+    {
+        /// <summary>Names that read as a level rather than an edge, for the delivery-policy suggestion.</summary>
+        private static readonly string[] LevelSuffixes =
+        {
+            "Ready", "Initialized", "Authenticated", "Updated", "Applied", "Loaded", "Configured",
+            "Selected", "Changed", "Available", "Complete", "Completed", "Enabled", "Connected",
+        };
+
+        /// <summary>Runs every check and returns the findings, most urgent first.</summary>
+        public static List<UpgradeFinding> Analyze(UpgradeAuditInput input)
+        {
+            var findings = new List<UpgradeFinding>();
+            if (input == null) return findings;
+
+            CheckTestables(input, findings);
+            CheckEventEnumAttribute(input, findings);
+            CheckExecutionOrder(input, findings);
+            CheckInspectorStrings(input, findings);
+            CheckDeliveryPolicies(input, findings);
+            CheckPayloadTypes(input, findings);
+            CheckLateDeliveries(input, findings);
+
+            findings.Sort((a, b) => b.Severity.CompareTo(a.Severity));
+            return findings;
+        }
+
+        private static void CheckTestables(UpgradeAuditInput input, List<UpgradeFinding> findings)
+        {
+            findings.Add(input.TestablesConfigured
+                ? new UpgradeFinding("1. Tests", UpgradeSeverity.Ok, "The package is listed in testables.")
+                : new UpgradeFinding("1. Tests", UpgradeSeverity.Action,
+                    "The package is not in Packages/manifest.json \"testables\", so its tests do not build.",
+                    new[] { "Add: \"testables\": [ \"com.crawfissoftware.eventspublisher\" ]" }));
+        }
+
+        private static void CheckEventEnumAttribute(UpgradeAuditInput input, List<UpgradeFinding> findings)
+        {
+            var unmarked = new List<string>();
+            foreach (Type enumType in input.EventEnums)
+            {
+                if (enumType != null && !enumType.IsDefined(typeof(EventEnumAttribute), false))
+                    unmarked.Add(enumType.FullName);
+            }
+
+            if (unmarked.Count == 0)
+            {
+                findings.Add(new UpgradeFinding("2. [EventEnum]", UpgradeSeverity.Ok,
+                    $"All {input.EventEnums.Count} event enums are marked."));
+                return;
+            }
+
+            findings.Add(new UpgradeFinding("2. [EventEnum]", UpgradeSeverity.Action,
+                $"{unmarked.Count} event enum(s) are not marked [EventEnum], so they are not registered " +
+                "before scenes load and do not appear in the Inspector dropdowns.", unmarked));
+        }
+
+        private static void CheckExecutionOrder(UpgradeAuditInput input, List<UpgradeFinding> findings)
+        {
+            if (input.SingletonSubclasses.Count == 0)
+            {
+                findings.Add(new UpgradeFinding("4. EventsFor<T>", UpgradeSeverity.Ok,
+                    "No EventsPublisherEnumsSingleton<T> subclasses remain."));
+                return;
+            }
+
+            var details = new List<string>();
+            foreach (Type type in input.SingletonSubclasses)
+            {
+                if (type == null) continue;
+                bool ordered = type.IsDefined(typeof(UnityEngine.DefaultExecutionOrderAttribute), false);
+                details.Add(type.FullName + (ordered ? "  [DefaultExecutionOrder]" : ""));
+            }
+
+            findings.Add(new UpgradeFinding("4. EventsFor<T>", UpgradeSeverity.Action,
+                $"{details.Count} scene-object publisher singleton(s) remain. EventsFor<T> is static and " +
+                "lazily initialized, so it needs no GameObject and no execution order. Any " +
+                "[DefaultExecutionOrder] marked below is load-bearing today and only orders Awake within " +
+                "one scene load batch, which is why additive scenes still race.", details));
+        }
+
+        private static void CheckInspectorStrings(UpgradeAuditInput input, List<UpgradeFinding> findings)
+        {
+            // Fields whose serialized value is a known event name: exact, no naming heuristic involved.
+            var fieldsHoldingNames = new HashSet<string>(StringComparer.Ordinal);
+            foreach (SerializedEventName found in input.SerializedEventNames)
+                fieldsHoldingNames.Add(found.FieldName);
+
+            var unmarked = new List<string>();
+            var suspected = new List<string>();
+            foreach (FieldInfo field in input.SerializedStringFields)
+            {
+                if (field == null || field.IsDefined(typeof(EventNameAttribute), false)) continue;
+
+                string label = field.DeclaringType?.Name + "." + field.Name;
+                if (fieldsHoldingNames.Contains(field.Name)) unmarked.Add(label + "  (holds an event name in an asset)");
+                else if (field.Name.IndexOf("event", StringComparison.OrdinalIgnoreCase) >= 0) suspected.Add(label);
+            }
+
+            if (unmarked.Count == 0 && suspected.Count == 0)
+            {
+                findings.Add(new UpgradeFinding("3. [EventName]", UpgradeSeverity.Ok,
+                    "No unmarked serialized string fields look like event names."));
+                return;
+            }
+
+            unmarked.AddRange(suspected);
+            findings.Add(new UpgradeFinding("3. [EventName]", unmarked.Count > suspected.Count ? UpgradeSeverity.Action : UpgradeSeverity.Suggestion,
+                $"{unmarked.Count} serialized string field(s) hold or look like event names and lack " +
+                "[EventName]. Add the attribute; do NOT change the field type to EventRef, which would " +
+                "change the serialized shape and lose every name already baked into a scene or prefab. " +
+                "Entries not annotated \"(holds an event name in an asset)\" are name-based guesses.",
+                unmarked));
+        }
+
+        private static void CheckDeliveryPolicies(UpgradeAuditInput input, List<UpgradeFinding> findings)
+        {
+            int total = 0, declared = 0;
+            var levelCandidates = new List<string>();
+
+            foreach (Type enumType in input.EventEnums)
+            {
+                if (enumType == null || !enumType.IsEnum) continue;
+                foreach (FieldInfo member in enumType.GetFields(BindingFlags.Public | BindingFlags.Static))
+                {
+                    total++;
+                    if (member.IsDefined(typeof(EventDeliveryAttribute), false)) { declared++; continue; }
+                    if (LooksLikeALevel(member.Name)) levelCandidates.Add(enumType.Name + "/" + member.Name);
+                }
+            }
+
+            if (total == 0) return;
+            if (declared == total)
+            {
+                findings.Add(new UpgradeFinding("6. Delivery", UpgradeSeverity.Ok,
+                    $"All {total} event members declare a delivery policy."));
+                return;
+            }
+
+            findings.Add(new UpgradeFinding("6. Delivery", UpgradeSeverity.Suggestion,
+                $"{total - declared} of {total} event members have no [EventDelivery], so they are " +
+                "Transient and a late subscriber hears nothing. Decide edge or level per event: an edge " +
+                "is a transition and is only meaningful in sequence; a level is a state and is " +
+                "self-describing, so replaying it is safe. Only levels should be Sticky. The names " +
+                "below read as levels, which is a guess — the runtime diagnostic below is evidence.",
+                levelCandidates));
+        }
+
+        private static bool LooksLikeALevel(string memberName)
+        {
+            for (int i = 0; i < LevelSuffixes.Length; i++)
+                if (memberName.EndsWith(LevelSuffixes[i], StringComparison.Ordinal)) return true;
+            return memberName.StartsWith("Is", StringComparison.Ordinal)
+                || memberName.StartsWith("Has", StringComparison.Ordinal);
+        }
+
+        private static void CheckPayloadTypes(UpgradeAuditInput input, List<UpgradeFinding> findings)
+        {
+            int total = 0, declared = 0;
+            foreach (Type enumType in input.EventEnums)
+            {
+                if (enumType == null || !enumType.IsEnum) continue;
+                foreach (FieldInfo member in enumType.GetFields(BindingFlags.Public | BindingFlags.Static))
+                {
+                    total++;
+                    if (member.IsDefined(typeof(EventPayloadAttribute), false)) declared++;
+                }
+            }
+
+            if (total == 0) return;
+            findings.Add(declared == 0
+                ? new UpgradeFinding("7. Payloads", UpgradeSeverity.Suggestion,
+                    $"None of the {total} event members declare [EventPayload], so every handler still " +
+                    "casts an object and a wrong cast fails inside the handler. Declaring a type makes " +
+                    "publishes and handlers compiler-checked, and lets the publisher report a mismatched " +
+                    "payload from a raw-string publish. Start with events that already carry data.")
+                : new UpgradeFinding("7. Payloads", UpgradeSeverity.Suggestion,
+                    $"{declared} of {total} event members declare [EventPayload]. Events with no " +
+                    "declaration stay unchecked, which is the intended default — migrate the ones that " +
+                    "carry data."));
+        }
+
+        private static void CheckLateDeliveries(UpgradeAuditInput input, List<UpgradeFinding> findings)
+        {
+            if (!input.DiagnosticsHaveData)
+            {
+                findings.Add(new UpgradeFinding("6. Delivery (evidence)", UpgradeSeverity.Suggestion,
+                    "No runtime data yet. Enter play mode and run the boot sequence, then re-run this " +
+                    "audit: every event whose subscribers arrived too late to hear it will be listed, " +
+                    "which turns the edge-or-level decision from a guess into a measurement."));
+                return;
+            }
+
+            if (input.LateDeliveries.Count == 0)
+            {
+                findings.Add(new UpgradeFinding("6. Delivery (evidence)", UpgradeSeverity.Ok,
+                    "No event was subscribed to after it had already been published during the recorded run."));
+                return;
+            }
+
+            var details = new List<string>();
+            foreach (EventsDiagnostics.Observation observation in input.LateDeliveries)
+            {
+                details.Add($"{observation.Name}  —  {observation.LateSubscribes} late subscriber(s), " +
+                            $"{observation.Publishes} publish(es)");
+            }
+
+            findings.Add(new UpgradeFinding("6. Delivery (evidence)", UpgradeSeverity.Action,
+                $"{details.Count} event(s) had a subscriber arrive after they were published, and it was " +
+                "delivered nothing. These are the Sticky candidates, and the events any hand-maintained " +
+                "bool mirror is compensating for. A late subscribe is evidence, not proof — an event may " +
+                "be genuinely transient and its late subscriber genuinely uninterested.", details));
+        }
+    }
+}

--- a/Editor/EventsUpgradeAudit.cs.meta
+++ b/Editor/EventsUpgradeAudit.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f5944b47620343fdaaba014ff0c55a32

--- a/Editor/EventsUpgradeAuditWindow.cs
+++ b/Editor/EventsUpgradeAuditWindow.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using UnityEditor;
+
+using UnityEngine;
+
+namespace CrawfisSoftware.Events.Editor
+{
+    /// <summary>
+    /// Gathers what <see cref="EventsUpgradeAudit"/> reasons about, and shows the result.
+    /// </summary>
+    /// <remarks>
+    /// <para>Everything here touches an editor API — <c>TypeCache</c>, the asset database, the file
+    /// system, IMGUI — and none of it makes a decision. The decisions are in
+    /// <see cref="EventsUpgradeAudit.Analyze"/>, which is why they are testable and this is not.</para>
+    /// <para><b>Copy report</b> puts the findings on the clipboard as plain text. That is the intended
+    /// route into an AI-assisted migration: run the audit in the project being upgraded, paste the
+    /// report alongside <c>Documentation~/upgrade-prompt.md</c>, and the assistant works from what this
+    /// project actually contains rather than from a guess about it.</para>
+    /// </remarks>
+    public class EventsUpgradeAuditWindow : EditorWindow
+    {
+        private const string PackageName = "com.crawfissoftware.eventspublisher";
+
+        private List<UpgradeFinding> _findings;
+        private Vector2 _scroll;
+
+        [MenuItem("Window/Events/Upgrade Audit")]
+        public static void Open()
+        {
+            GetWindow<EventsUpgradeAuditWindow>("Event Upgrade Audit").Refresh();
+        }
+
+        private void OnGUI()
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                if (GUILayout.Button("Refresh")) Refresh();
+                using (new EditorGUI.DisabledScope(_findings == null))
+                {
+                    if (GUILayout.Button("Copy report"))
+                    {
+                        EditorGUIUtility.systemCopyBuffer = BuildReport(_findings);
+                        Debug.Log("Event upgrade audit copied to the clipboard.");
+                    }
+                }
+            }
+
+            if (_findings == null)
+            {
+                EditorGUILayout.HelpBox("Press Refresh to scan the project.", MessageType.Info);
+                return;
+            }
+
+            EditorGUILayout.HelpBox(
+                "Enter play mode and run the boot sequence before refreshing. The delivery-policy " +
+                "evidence comes from what actually happened during a run.", MessageType.Info);
+
+            _scroll = EditorGUILayout.BeginScrollView(_scroll);
+            foreach (UpgradeFinding finding in _findings)
+            {
+                EditorGUILayout.LabelField(finding.Step, EditorStyles.boldLabel);
+                EditorGUILayout.HelpBox(finding.Summary, MessageTypeFor(finding.Severity));
+                foreach (string detail in finding.Details)
+                    EditorGUILayout.LabelField("    " + detail, EditorStyles.miniLabel);
+                EditorGUILayout.Space();
+            }
+            EditorGUILayout.EndScrollView();
+        }
+
+        private static MessageType MessageTypeFor(UpgradeSeverity severity)
+        {
+            switch (severity)
+            {
+                case UpgradeSeverity.Action: return MessageType.Warning;
+                case UpgradeSeverity.Suggestion: return MessageType.Info;
+                default: return MessageType.None;
+            }
+        }
+
+        private void Refresh()
+        {
+            _findings = EventsUpgradeAudit.Analyze(Gather());
+        }
+
+        /// <summary>Collects the project's current state for the analysis.</summary>
+        internal static UpgradeAuditInput Gather()
+        {
+            List<Type> singletons = CollectSingletonSubclasses();
+            List<Type> eventEnums = CollectEventEnums(singletons);
+
+            return new UpgradeAuditInput
+            {
+                EventEnums = eventEnums,
+                SingletonSubclasses = singletons,
+                SerializedStringFields = CollectSerializedStringFields(),
+                SerializedEventNames = CollectSerializedEventNames(eventEnums),
+                TestablesConfigured = IsPackageInTestables(),
+                LateDeliveries = EventsDiagnostics.GetLateDeliveries(),
+                DiagnosticsHaveData = EventsDiagnostics.GetAll().Count > 0,
+            };
+        }
+
+        private static List<Type> CollectSingletonSubclasses()
+        {
+            var found = new List<Type>();
+            foreach (Type type in TypeCache.GetTypesDerivedFrom(typeof(EventsPublisherEnumsSingleton<>)))
+                if (!type.IsAbstract) found.Add(type);
+            return found;
+        }
+
+        /// <summary>
+        /// Finds every enum acting as an event family, whether or not it is marked yet.
+        /// </summary>
+        /// <remarks>Three sources, because a project part-way through the migration has families in
+        /// each: already marked with the attribute, still behind a singleton subclass, and named in a
+        /// <c>EventsFor&lt;T&gt;</c> type argument in source. The last needs a source scan — a type
+        /// argument leaves no trace this tool can reflect over.</remarks>
+        private static List<Type> CollectEventEnums(List<Type> singletons)
+        {
+            var found = new List<Type>();
+            var seen = new HashSet<Type>();
+
+            void Add(Type type)
+            {
+                if (type != null && type.IsEnum && seen.Add(type)) found.Add(type);
+            }
+
+            foreach (Type type in TypeCache.GetTypesWithAttribute<EventEnumAttribute>()) Add(type);
+
+            foreach (Type subclass in singletons)
+            {
+                for (Type baseType = subclass.BaseType; baseType != null; baseType = baseType.BaseType)
+                {
+                    if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(EventsPublisherEnumsSingleton<>))
+                    {
+                        Add(baseType.GetGenericArguments()[0]);
+                        break;
+                    }
+                }
+            }
+
+            foreach (string name in ScanSourceForFacadeTypeArguments()) Add(ResolveEnumByName(name));
+            return found;
+        }
+
+        private static readonly Regex FacadeUsage =
+            new Regex(@"EventsFor\s*<\s*([\w\.]+)\s*>", RegexOptions.Compiled);
+
+        private static HashSet<string> ScanSourceForFacadeTypeArguments()
+        {
+            var names = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string path in SafeEnumerateFiles("Assets", "*.cs"))
+            {
+                string text;
+                try { text = File.ReadAllText(path); }
+                catch (IOException) { continue; }
+
+                foreach (Match match in FacadeUsage.Matches(text)) names.Add(match.Groups[1].Value);
+            }
+            return names;
+        }
+
+        private static Type ResolveEnumByName(string name)
+        {
+            string simpleName = name.Substring(name.LastIndexOf('.') + 1);
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly.IsDynamic) continue;
+                Type[] types;
+                try { types = assembly.GetTypes(); }
+                catch (ReflectionTypeLoadException e) { types = e.Types; }
+                catch (Exception) { continue; }
+
+                foreach (Type type in types)
+                    if (type != null && type.IsEnum && type.Name == simpleName) return type;
+            }
+            return null;
+        }
+
+        private static List<FieldInfo> CollectSerializedStringFields()
+        {
+            var fields = new List<FieldInfo>();
+            var types = new List<Type>();
+            types.AddRange(TypeCache.GetTypesDerivedFrom<MonoBehaviour>());
+            types.AddRange(TypeCache.GetTypesDerivedFrom<ScriptableObject>());
+
+            foreach (Type type in types)
+            {
+                if (type == null || type.Assembly == typeof(EventsUpgradeAudit).Assembly) continue;
+                foreach (FieldInfo field in type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                {
+                    if (field.FieldType != typeof(string) && field.FieldType != typeof(List<string>)) continue;
+                    bool serialized = field.IsPublic
+                        ? !field.IsDefined(typeof(NonSerializedAttribute), false)
+                        : field.IsDefined(typeof(SerializeField), false);
+                    if (serialized) fields.Add(field);
+                }
+            }
+            return fields;
+        }
+
+        // A serialized string in Unity YAML: two spaces or more, a key, a colon, then the value.
+        private static readonly Regex YamlEntry = new Regex(@"^\s+(\w+):\s*(\S.*?)\s*$", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Finds serialized fields whose value is a known event name, by reading the assets directly.
+        /// </summary>
+        /// <remarks>This is the one check with no heuristic in it. A field called <c>_trigger</c> holding
+        /// "GameFlowEvents/GameStarting" is found here and would be missed by any amount of guessing from
+        /// field names. Requires text-serialized assets; a project set to force-binary serialization gets
+        /// nothing from this and falls back to the name-based guesses.</remarks>
+        private static List<SerializedEventName> CollectSerializedEventNames(List<Type> eventEnums)
+        {
+            var known = new HashSet<string>(StringComparer.Ordinal);
+            foreach (Type enumType in eventEnums)
+            {
+                string prefix = EventsRegistry.GetPrefix(enumType);
+                foreach (string member in Enum.GetNames(enumType)) known.Add(prefix + "/" + member);
+            }
+
+            var found = new List<SerializedEventName>();
+            if (known.Count == 0) return found;
+
+            foreach (string path in SafeEnumerateFiles("Assets", "*.unity", "*.prefab", "*.asset"))
+            {
+                string[] lines;
+                try { lines = File.ReadAllLines(path); }
+                catch (IOException) { continue; }
+
+                foreach (string line in lines)
+                {
+                    Match match = YamlEntry.Match(line);
+                    if (match.Success && known.Contains(match.Groups[2].Value))
+                        found.Add(new SerializedEventName(path, match.Groups[1].Value, match.Groups[2].Value));
+                }
+            }
+            return found;
+        }
+
+        private static IEnumerable<string> SafeEnumerateFiles(string root, params string[] patterns)
+        {
+            if (!Directory.Exists(root)) yield break;
+            foreach (string pattern in patterns)
+            {
+                string[] paths;
+                try { paths = Directory.GetFiles(root, pattern, SearchOption.AllDirectories); }
+                catch (Exception) { continue; }
+                foreach (string path in paths) yield return path;
+            }
+        }
+
+        private static bool IsPackageInTestables()
+        {
+            try
+            {
+                string manifest = Path.Combine(Path.GetDirectoryName(Application.dataPath) ?? ".", "Packages/manifest.json");
+                return File.Exists(manifest) && File.ReadAllText(manifest).Contains(PackageName + "\"");
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>Renders the findings as plain text, for pasting into an assistant or an issue.</summary>
+        internal static string BuildReport(IReadOnlyList<UpgradeFinding> findings)
+        {
+            var report = new StringBuilder();
+            report.AppendLine("EventsPublisher upgrade audit");
+            report.AppendLine();
+            foreach (UpgradeFinding finding in findings)
+            {
+                report.AppendLine($"[{finding.Severity}] {finding.Step}: {finding.Summary}");
+                foreach (string detail in finding.Details) report.AppendLine("    - " + detail);
+                report.AppendLine();
+            }
+            return report.ToString();
+        }
+    }
+}

--- a/Editor/EventsUpgradeAuditWindow.cs
+++ b/Editor/EventsUpgradeAuditWindow.cs
@@ -126,12 +126,7 @@ namespace CrawfisSoftware.Events.Editor
             var found = new List<Type>();
             var seen = new HashSet<Type>();
 
-            void Add(Type type)
-            {
-                if (type != null && type.IsEnum && seen.Add(type)) found.Add(type);
-            }
-
-            foreach (Type type in TypeCache.GetTypesWithAttribute<EventEnumAttribute>()) Add(type);
+            foreach (Type type in TypeCache.GetTypesWithAttribute<EventEnumAttribute>()) AddEnum(found, seen, type);
 
             foreach (Type subclass in singletons)
             {
@@ -139,14 +134,20 @@ namespace CrawfisSoftware.Events.Editor
                 {
                     if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(EventsPublisherEnumsSingleton<>))
                     {
-                        Add(baseType.GetGenericArguments()[0]);
+                        AddEnum(found, seen, baseType.GetGenericArguments()[0]);
                         break;
                     }
                 }
             }
 
-            foreach (string name in ScanSourceForFacadeTypeArguments()) Add(ResolveEnumByName(name));
+            foreach (string name in ScanSourceForFacadeTypeArguments())
+                AddEnum(found, seen, ResolveEnumByName(name));
             return found;
+        }
+
+        private static void AddEnum(List<Type> found, HashSet<Type> seen, Type type)
+        {
+            if (type != null && type.IsEnum && seen.Add(type)) found.Add(type);
         }
 
         private static readonly Regex FacadeUsage =
@@ -260,7 +261,8 @@ namespace CrawfisSoftware.Events.Editor
             try
             {
                 string manifest = Path.Combine(Path.GetDirectoryName(Application.dataPath) ?? ".", "Packages/manifest.json");
-                return File.Exists(manifest) && File.ReadAllText(manifest).Contains(PackageName + "\"");
+                return File.Exists(manifest)
+                    && EventsUpgradeAudit.IsListedInTestables(File.ReadAllText(manifest), PackageName);
             }
             catch (Exception)
             {

--- a/Editor/EventsUpgradeAuditWindow.cs.meta
+++ b/Editor/EventsUpgradeAuditWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5d406b8ff46243ff8a82cd4891c2c2f7

--- a/README.md
+++ b/README.md
@@ -81,10 +81,30 @@ serialized shape, so Unity cannot carry the old value across and every name alre
 a `.unity` or `.prefab` asset would be lost. The attribute leaves the field a string, so
 existing values keep working and only the authoring experience changes.
 
+`EventRef` also has publisher overloads, so an authored call site never unwraps the string:
+
+```csharp
+EventsPublisher.Instance.PublishEvent(_eventToFire, this, null);
+```
+
 The dropdown lists every member of every enum marked `[EventEnum]`, grouped by family. A value
 that matches no known event is shown as `Missing/<value>` rather than silently cleared, so a
 name whose enum is not yet marked — or that has since been renamed — is surfaced instead of
 being replaced the moment the Inspector paints it.
+
+## Name collisions
+
+Event names are projected from the enum's simple type name, so two enums both called
+`Events` in different namespaces would share every event. The publisher reports this at
+registration. Fix it with an explicit prefix on one of them:
+
+```csharp
+[EventEnum(Prefix = "GuiEvents")]
+public enum Events { ... }
+```
+
+Only that enum's names change. Set it when the enum is introduced — changing it later
+renames every one of its events and breaks any name already serialized.
 
 ## Diagnostics
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,94 @@
 # EventsPublisher
 Event system for Unity
+
+## Publishing and subscribing
+
+`EventsFor<T>` is the entry point, one closed type per enum family. It is static and
+lazily initialized, so it needs no GameObject, no `[DefaultExecutionOrder]`, and works
+from a scene loaded in any order:
+
+```csharp
+using TempleRunBus = CrawfisSoftware.Events.EventsFor<TempleRunEvents>;
+
+private void Awake()
+{
+    TempleRunBus.Subscribe(TempleRunEvents.PlayerDied, OnPlayerDied);
+}
+
+private void OnDestroy()
+{
+    TempleRunBus.Unsubscribe(TempleRunEvents.PlayerDied, OnPlayerDied);
+}
+
+private void Die()
+{
+    TempleRunBus.Publish(TempleRunEvents.PlayerDied, this, _finalDistance);
+}
+```
+
+`EventsPublisherEnumsSingleton<T>` still works and forwards to the same facade, so
+existing scene objects keep running unchanged.
+
+## Delivery policy
+
+Under additive scene loading a subscriber's `Awake` may run after an event has already
+been published. Declare a policy so the publisher retains the event rather than making
+every subscriber mirror it into a `bool`:
+
+```csharp
+[EventEnum]
+public enum TempleRunEvents
+{
+    PlayerFailingAtTurn = 12,                              // edge  -> Transient (default)
+    [EventDelivery(EventDelivery.Sticky)] PlayerDied = 5,  // level -> retained
+    [EventDelivery(EventDelivery.Replay)] SegmentCreated,  // accumulation -> journalled
+}
+```
+
+| Policy | A subscriber arriving later gets |
+|---|---|
+| `Transient` | nothing |
+| `Sticky` | the last `(sender, data)`, immediately on subscribe |
+| `Replay` | every `(sender, data)`, in order, immediately on subscribe |
+
+The judgement per event is **edge or level**. An edge is a transition and is only
+meaningful in sequence, so replaying it is wrong. A level is a state and is
+self-describing — received once, late, with no history, it still tells the truth.
+
+`TryGetLast` reads the retained value without subscribing, for a one-shot read, a
+non-`MonoBehaviour`, or an editor tool.
+
+`[EventEnum]` registers a family before any scene loads. It only matters when an event
+name reaches the publisher as a raw string — from a serialized Inspector field — without
+the facade ever being touched; anything published or subscribed through `EventsFor<T>`
+is registered by that first touch.
+
+A `Replay` journal grows for as long as its publisher frame lives. Scope it by pushing a
+publisher frame when the owning scene loads and popping it on unload.
+
+## Diagnostics
+
+`EventsPublisher.StrictMode` — on by default in the editor and development builds —
+reports publishing an event name no frame has registered. Without it, a misspelled name
+reaches no subscriber while still notifying "all events" subscribers, so the logger
+prints it and the system looks healthy.
+
+## Running the tests
+
+The tests live in `Tests/Editor` and are EditMode tests. Unity only builds a package's
+tests when the consuming project opts in, so add the package to `testables` in the
+project's `Packages/manifest.json`:
+
+```json
+{
+  "testables": [ "com.crawfissoftware.eventspublisher" ]
+}
+```
+
+They then appear under **Window > General > Test Runner > EditMode**.
+
+## Design notes
+
+`Documentation~/adr/0001-event-identity-and-delivery.md` records why events are keyed on
+strings, what that costs, and the staged plan for making the string a projection rather
+than the identity.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,51 @@ is registered by that first touch.
 A `Replay` journal grows for as long as its publisher frame lives. Scope it by pushing a
 publisher frame when the owning scene loads and popping it on unload.
 
+## Typed payloads
+
+`data` is an `object`, so a handler that casts it wrongly fails at runtime, inside the
+handler, with nothing naming what the event was supposed to carry. Declare the payload
+type and the compiler checks it instead:
+
+```csharp
+[EventEnum]
+public enum TempleRunEvents
+{
+    [EventPayload(typeof(PlayerFailedData))]
+    [EventDelivery(EventDelivery.Sticky)]
+    PlayerFailed,
+}
+
+// Resolve once. Everything downstream of this line is compiler-checked.
+private static readonly EventId<PlayerFailedData> Failed =
+    EventsFor<TempleRunEvents>.Id<PlayerFailedData>(TempleRunEvents.PlayerFailed);
+
+private void OnEnable()  => Failed.Subscribe(OnPlayerFailed);
+private void OnDisable() => Failed.Unsubscribe(OnPlayerFailed);
+
+// No cast, and a wrong parameter type will not compile.
+private void OnPlayerFailed(string eventName, object sender, PlayerFailedData data) { }
+
+private void Fail() => Failed.Publish(this, new PlayerFailedData(...));
+```
+
+The type argument is written once, in the `static readonly` field, and checked against
+the attribute at startup. Two call sites declaring different types for the same event is
+the one mistake the compiler cannot catch, so it is reported the moment the second one
+is minted.
+
+Adoption is per event and both directions keep working: a typed publish reaches existing
+untyped subscribers, an untyped publish reaches typed handlers, and `SubscribeToAllEvents`
+still receives `object`, so the global logger and event history do not change.
+
+An untyped publish carrying the wrong payload is reported at the publisher — naming the
+event, the expected type, the actual type, and the sender — and typed handlers are
+skipped rather than handed a value they cannot use. An event with no `[EventPayload]` is
+unchecked, exactly as before.
+
+Use `EventId<TData>.Of("Some/Name")` for a name no enum can annotate. `typeof(object)`
+declares an intentionally untyped payload.
+
 ## Authoring event names in the Inspector
 
 Scene data has no compile step, so a plain `[SerializeField] string` event name has no check
@@ -111,7 +156,8 @@ renames every one of its events and breaks any name already serialized.
 `EventsPublisher.StrictMode` — on by default in the editor and development builds —
 reports publishing an event name no frame has registered. Without it, a misspelled name
 reaches no subscriber while still notifying "all events" subscribers, so the logger
-prints it and the system looks healthy.
+prints it and the system looks healthy. It also reports a publish whose payload is not
+what the event declared it carries, naming the sender.
 
 ## Running the tests
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,23 @@ reaches no subscriber while still notifying "all events" subscribers, so the log
 prints it and the system looks healthy. It also reports a publish whose payload is not
 what the event declared it carries, naming the sender.
 
+## Upgrading an existing project
+
+**Window > Events > Upgrade Audit** reflects over the project and reads its assets, then
+reports which upgrade steps it has and has not taken — so it describes the project in
+front of it rather than a generic one. Findings are graded: an *Action* is discovered
+from evidence, a *Suggestion* is a guess or a judgement it cannot make for you.
+
+Enter play mode and run the boot sequence before refreshing. `EventsDiagnostics` records
+every event that was subscribed to *after* it had already been published — the delivery
+that was missed — so the edge-or-level decision is read off a run rather than guessed.
+It is on in the editor and development builds, off in release.
+
+`Documentation~/UPGRADING.md` is the step-by-step guide, and
+`Documentation~/upgrade-prompt.md` is a project-agnostic prompt for doing it with an AI
+assistant. Nothing in the upgrade is required — the package is source-compatible, and
+every step is opt-in.
+
 ## Running the tests
 
 The tests live in `Tests/Editor` and are EditMode tests. Unity only builds a package's

--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ is registered by that first touch.
 A `Replay` journal grows for as long as its publisher frame lives. Scope it by pushing a
 publisher frame when the owning scene loads and popping it on unload.
 
+## Authoring event names in the Inspector
+
+Scene data has no compile step, so a plain `[SerializeField] string` event name has no check
+of any kind. Two ways to get a dropdown of real events instead:
+
+```csharp
+[EventName] [SerializeField] private string _eventToFire;   // existing fields
+[SerializeField] private EventRef _eventToFire;             // new fields
+```
+
+Prefer `[EventName]` when converting an existing field. Changing a field's type changes its
+serialized shape, so Unity cannot carry the old value across and every name already baked into
+a `.unity` or `.prefab` asset would be lost. The attribute leaves the field a string, so
+existing values keep working and only the authoring experience changes.
+
+The dropdown lists every member of every enum marked `[EventEnum]`, grouped by family. A value
+that matches no known event is shown as `Missing/<value>` rather than silently cleared, so a
+name whose enum is not yet marked — or that has since been renamed — is surfaced instead of
+being replaced the moment the Inspector paints it.
+
 ## Diagnostics
 
 `EventsPublisher.StrictMode` — on by default in the editor and development builds —

--- a/Runtime/AssemblyInfo.cs
+++ b/Runtime/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System.Runtime.CompilerServices;
+
+// The test assembly exercises internals deliberately: EventsRegistry's reset, so each test starts
+// from clean static state, and EventsPublisherInternal's registration probe. Neither belongs on the
+// public API — a public "reset everything" would be a footgun in game code.
+[assembly: InternalsVisibleTo("CrawfisSoftware.EventsPublisher.Tests")]

--- a/Runtime/AssemblyInfo.cs.meta
+++ b/Runtime/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 94da9a9c09c14b97a8c8fa0c4ae26f59

--- a/Runtime/EventDelivery.cs
+++ b/Runtime/EventDelivery.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// How the publisher treats an event for subscribers that arrive after it was published.
+    /// </summary>
+    /// <remarks>
+    /// The per-event judgement is whether the event is an <em>edge</em> or a <em>level</em>. An edge is
+    /// a transition — "the menu just closed" — and is only meaningful in sequence, so replaying it is
+    /// wrong. A level is a state — "the menu is closed" — and is self-describing: received once, late,
+    /// with no history, it still tells the whole truth. Only levels are safe to retain.
+    /// </remarks>
+    public enum EventDelivery
+    {
+        /// <summary>
+        /// Fire and forget. A subscriber that arrives later does not see it. The default, and correct
+        /// for edges: requests, transitions, one-shot notifications, per-frame gameplay events.
+        /// </summary>
+        Transient = 0,
+
+        /// <summary>
+        /// The last published <c>(sender, data)</c> is retained and delivered to a subscriber
+        /// immediately on subscribe. Correct for levels — lifecycle and state events whose current
+        /// value a late subscriber needs.
+        /// </summary>
+        Sticky = 1,
+
+        /// <summary>
+        /// Every published <c>(sender, data)</c> is retained in order and delivered to a subscriber
+        /// immediately on subscribe. For accumulations a late subscriber must rebuild.
+        /// </summary>
+        /// <remarks>The journal grows for as long as its publisher frame lives, so this is the policy
+        /// that needs scoping: push a publisher frame when the owning scene loads and pop it on unload,
+        /// and the journal is discarded with the scene. Growth past
+        /// <see cref="EventsRegistry.JournalWarningThreshold"/> entries is reported rather than
+        /// silently truncated.</remarks>
+        Replay = 2,
+    }
+
+    /// <summary>
+    /// Declares the <see cref="EventDelivery"/> policy for a single enum member.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// [EventEnum]
+    /// public enum TempleRunEvents
+    /// {
+    ///     PlayerFailingAtTurn = 12,                          // edge → Transient (the default)
+    ///     [EventDelivery(EventDelivery.Sticky)] PlayerDied = 5,   // level → retained
+    /// }
+    /// </code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
+    public sealed class EventDeliveryAttribute : Attribute
+    {
+        /// <summary>The declared delivery policy.</summary>
+        public EventDelivery Delivery { get; }
+
+        /// <summary>Declares the delivery policy for the annotated enum member.</summary>
+        public EventDeliveryAttribute(EventDelivery delivery)
+        {
+            Delivery = delivery;
+        }
+    }
+}

--- a/Runtime/EventDelivery.cs.meta
+++ b/Runtime/EventDelivery.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 924cf9e5e2d046d78a32e67124b4fbe2

--- a/Runtime/EventEnumAttribute.cs
+++ b/Runtime/EventEnumAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// Marks an enum whose members name published events, so that they are registered before any
+    /// scene loads.
+    /// </summary>
+    /// <remarks>
+    /// <para>Registration normally happens the first time <see cref="EventsFor{T}"/> is touched, which
+    /// is inherently early enough for anything published or subscribed through that facade. This
+    /// attribute covers the remaining case: an event name reaching the publisher as a raw string —
+    /// from a serialized Inspector field, for example — without the facade for its enum ever having
+    /// been used. Without it, such a publish is unregistered and
+    /// <see cref="EventsPublisher.StrictMode"/> reports it.</para>
+    /// <para>Annotated enums are swept at
+    /// <see cref="UnityEngine.RuntimeInitializeLoadType.BeforeSceneLoad"/>, which runs after
+    /// assemblies load and before the first scene's <c>Awake</c> — and therefore before every
+    /// additively-loaded scene's <c>Awake</c>.</para>
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Enum, Inherited = false, AllowMultiple = false)]
+    public sealed class EventEnumAttribute : Attribute
+    {
+    }
+}

--- a/Runtime/EventEnumAttribute.cs
+++ b/Runtime/EventEnumAttribute.cs
@@ -21,5 +21,17 @@ namespace CrawfisSoftware.Events
     [AttributeUsage(AttributeTargets.Enum, Inherited = false, AllowMultiple = false)]
     public sealed class EventEnumAttribute : Attribute
     {
+        /// <summary>
+        /// Overrides the event-name prefix, which otherwise defaults to the enum's simple type name.
+        /// </summary>
+        /// <remarks>
+        /// <para>Event names are projected from <see cref="Type.Name"/>, not <see cref="Type.FullName"/>,
+        /// so two enums with the same simple name in different namespaces would silently share every
+        /// event. Setting an explicit prefix on one of them resolves that without renaming the type and
+        /// without disturbing any name already baked into a scene or prefab.</para>
+        /// <para>Changing this on an enum already in use renames every one of its events, which breaks
+        /// any name that has been serialized. Choose it when the enum is introduced.</para>
+        /// </remarks>
+        public string Prefix { get; set; }
     }
 }

--- a/Runtime/EventEnumAttribute.cs.meta
+++ b/Runtime/EventEnumAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 88bb8c26adbd44fdad0cb0ab18184ead

--- a/Runtime/EventId.cs
+++ b/Runtime/EventId.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// An interned handle for an event name: the identity the publisher keys on, with the string
+    /// available as a projection off it.
+    /// </summary>
+    /// <remarks>
+    /// <para>This is the shape the whole design has been moving toward — the string becomes
+    /// <see cref="Name"/>, derived and used for display and for the erased observer channel, while the
+    /// thing the dictionaries key on is a value the compiler hands you.</para>
+    /// <para>Resolving a name to an <see cref="EventId"/> costs one dictionary lookup, and every publish
+    /// or subscribe through that id afterwards costs none. <see cref="EventsFor{T}"/> resolves each
+    /// member of an enum family once at construction, so the enum path never hashes a string again.</para>
+    /// <para>A default <see cref="EventId"/> is deliberately not a valid handle, so a field nobody
+    /// assigned cannot silently alias the first registered event.</para>
+    /// </remarks>
+    public readonly struct EventId : IEquatable<EventId>
+    {
+        // One-based, so default(EventId) is 0 and therefore invalid rather than aliasing index 0.
+        private readonly int _handle;
+
+        internal EventId(int handle)
+        {
+            _handle = handle;
+        }
+
+        internal int Handle => _handle;
+
+        /// <summary>True when this refers to an interned event name.</summary>
+        public bool IsValid => _handle != 0;
+
+        /// <summary>
+        /// The projected event name. Display, serialization and erased observers only — never the key.
+        /// </summary>
+        public string Name => EventsRegistry.GetInternedName(this);
+
+        /// <summary>Resolves an event name to its handle, interning it on first use.</summary>
+        public static EventId Of(string eventName) => EventsRegistry.Intern(eventName);
+
+        public bool Equals(EventId other) => _handle == other._handle;
+        public override bool Equals(object obj) => obj is EventId other && Equals(other);
+        public override int GetHashCode() => _handle;
+        public override string ToString() => Name ?? "<unset>";
+
+        public static bool operator ==(EventId left, EventId right) => left._handle == right._handle;
+        public static bool operator !=(EventId left, EventId right) => left._handle != right._handle;
+    }
+
+    /// <summary>
+    /// The <see cref="EventId"/> entry points on a publisher, kept off <see cref="IEventsPublisher{T}"/>
+    /// so that adding them breaks no existing implementer.
+    /// </summary>
+    /// <remarks>Callers that hold a resolved id use these to skip the name lookup entirely. Everything
+    /// keeps working without them — the string-keyed API resolves the id itself.</remarks>
+    public interface IEventIdPublisher
+    {
+        /// <summary>Publishes a pre-resolved event.</summary>
+        void PublishEvent(EventId eventId, object sender, object data);
+
+        /// <summary>Subscribes to a pre-resolved event, receiving any retained value immediately.</summary>
+        void SubscribeToEvent(EventId eventId, Action<string, object, object> callback);
+
+        /// <summary>Unsubscribes from a pre-resolved event.</summary>
+        void UnsubscribeToEvent(EventId eventId, Action<string, object, object> callback);
+
+        /// <summary>Registers a pre-resolved event.</summary>
+        void RegisterEvent(EventId eventId);
+
+        /// <summary>Reads the retained value for a pre-resolved event, without subscribing.</summary>
+        bool TryGetLast(EventId eventId, out object sender, out object data);
+    }
+}

--- a/Runtime/EventId.cs.meta
+++ b/Runtime/EventId.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca59d019c44045e785bfffe75601165b

--- a/Runtime/EventIdOfT.cs
+++ b/Runtime/EventIdOfT.cs
@@ -1,0 +1,81 @@
+using System;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// An <see cref="EventId"/> that also carries the type of the payload the event delivers, so that
+    /// publishing and subscribing through it are checked by the compiler.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>What this does and does not guarantee.</b> Once a call site holds an
+    /// <see cref="EventId{TData}"/>, publishing the wrong payload and writing a handler with the wrong
+    /// parameter type are both compile errors — there is no cast to get wrong. That covers every call
+    /// site except one: the place the type argument is first written, in <see cref="Of"/> or
+    /// <see cref="EventsFor{T}.Id{TData}"/>. That single point is checked at runtime against the
+    /// <see cref="EventPayloadAttribute"/> declaration, so getting it wrong is a startup error naming
+    /// both types rather than an <see cref="InvalidCastException"/> inside a handler much later.</para>
+    /// <para>Declare the type once, in a <c>static readonly</c> field, and use that field everywhere:
+    /// the runtime-checked point is then hit once at type initialization, and everything downstream of
+    /// it is the compiler's problem.</para>
+    /// <para>Erasure is preserved. Subscribers registered through the untyped API still receive
+    /// <see cref="object"/>, so the global logger, <c>EventHistory</c> and the editor menus see every
+    /// typed event without changing.</para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// private static readonly EventId&lt;PlayerFailedData&gt; Failed =
+    ///     EventsFor&lt;TempleRunEvents&gt;.Id&lt;PlayerFailedData&gt;(TempleRunEvents.PlayerFailed);
+    ///
+    /// void OnEnable()  =&gt; Failed.Subscribe(OnPlayerFailed);
+    /// void OnDisable() =&gt; Failed.Unsubscribe(OnPlayerFailed);
+    ///
+    /// // data is PlayerFailedData. No cast, and a wrong parameter type will not compile.
+    /// private void OnPlayerFailed(string eventName, object sender, PlayerFailedData data) { }
+    /// </code>
+    /// </example>
+    /// <typeparam name="TData">The type of the <c>data</c> argument this event carries.</typeparam>
+    public readonly struct EventId<TData> : IEquatable<EventId<TData>>
+    {
+        private readonly EventId _id;
+
+        internal EventId(EventId id)
+        {
+            _id = id;
+        }
+
+        /// <summary>The erased identity, for the untyped API and for the observer channel.</summary>
+        public EventId Untyped => _id;
+
+        /// <summary>True when this refers to an interned event name.</summary>
+        public bool IsValid => _id.IsValid;
+
+        /// <summary>The projected event name. Display and erased observers only — never the key.</summary>
+        public string Name => _id.Name;
+
+        /// <summary>
+        /// Resolves an event name to a typed identity, declaring <typeparamref name="TData"/> as its
+        /// payload type.
+        /// </summary>
+        /// <remarks>The escape hatch for names no enum can annotate. For an enum family, prefer
+        /// <see cref="EventsFor{T}.Id{TData}"/>, which reads the type from
+        /// <see cref="EventPayloadAttribute"/> and so keeps the declaration next to the event.
+        /// Either way, the first declaration wins and a differing one is reported.</remarks>
+        public static EventId<TData> Of(string eventName)
+        {
+            EventId id = EventsRegistry.Intern(eventName);
+            EventsRegistry.DeclarePayload(id, typeof(TData));
+            return new EventId<TData>(id);
+        }
+
+        /// <summary>Widens to the erased identity, so a typed id works anywhere an untyped one does.</summary>
+        public static implicit operator EventId(EventId<TData> eventId) => eventId._id;
+
+        public bool Equals(EventId<TData> other) => _id.Equals(other._id);
+        public override bool Equals(object obj) => obj is EventId<TData> other && Equals(other);
+        public override int GetHashCode() => _id.GetHashCode();
+        public override string ToString() => _id.ToString();
+
+        public static bool operator ==(EventId<TData> left, EventId<TData> right) => left._id == right._id;
+        public static bool operator !=(EventId<TData> left, EventId<TData> right) => left._id != right._id;
+    }
+}

--- a/Runtime/EventIdOfT.cs.meta
+++ b/Runtime/EventIdOfT.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8438e34ba51a421cb2ebbc646284466e

--- a/Runtime/EventPayloadAttribute.cs
+++ b/Runtime/EventPayloadAttribute.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// Declares the payload type an enum member carries, so that a typed identity can be resolved for
+    /// it and a publish of the wrong payload is reported.
+    /// </summary>
+    /// <remarks>
+    /// <para>This is the single declaration of an event's payload. It sits next to the member, the way
+    /// <see cref="EventDeliveryAttribute"/> does, and is read once at facade construction rather than
+    /// per publish.</para>
+    /// <para>Declaring it is what lets the publisher check an <em>untyped</em> publish — a raw string,
+    /// or an Inspector-authored <see cref="EventRef"/> — against what the event is supposed to carry.
+    /// Without a declaration the publisher has nothing to compare against and the payload stays
+    /// unchecked, which is the pre-Stage-3 behaviour and remains the default.</para>
+    /// <para>An event with no payload is left unannotated. Annotating one as <c>typeof(void)</c> is not
+    /// supported; use <c>typeof(object)</c> if a payload is genuinely untyped, which declares "anything
+    /// goes" explicitly rather than by omission.</para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// [EventEnum]
+    /// public enum TempleRunEvents
+    /// {
+    ///     [EventPayload(typeof(PlayerFailedData))]
+    ///     [EventDelivery(EventDelivery.Sticky)]
+    ///     PlayerFailed = 5,
+    ///
+    ///     PlayerJumped = 6,   // no payload
+    /// }
+    /// </code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
+    public sealed class EventPayloadAttribute : Attribute
+    {
+        /// <summary>The type of the <c>data</c> argument this event carries.</summary>
+        public Type PayloadType { get; }
+
+        /// <summary>Declares the payload type for the annotated enum member.</summary>
+        public EventPayloadAttribute(Type payloadType)
+        {
+            PayloadType = payloadType;
+        }
+    }
+}

--- a/Runtime/EventPayloadAttribute.cs.meta
+++ b/Runtime/EventPayloadAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9439b637dc304683b68b950ece7342c5

--- a/Runtime/EventRef.cs
+++ b/Runtime/EventRef.cs
@@ -1,0 +1,79 @@
+using System;
+
+using UnityEngine;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// A serializable reference to a published event, authored in the Inspector as a dropdown rather
+    /// than typed as a free-text string.
+    /// </summary>
+    /// <remarks>
+    /// <para>Scene data has no compile step, so a <c>[SerializeField] string</c> event name has no check
+    /// of any kind — a typo survives to runtime and the event silently reaches nobody. This carries the
+    /// projected name but restricts authoring to names that actually exist.</para>
+    /// <para>The stored value is the projected name (<c>"TypeName/MemberName"</c>) rather than the type
+    /// and member separately, so it is the same string the publisher keys on and the same string already
+    /// baked into existing scenes and prefabs.</para>
+    /// <para>The dropdown is populated from enums marked <see cref="EventEnumAttribute"/>. A value that
+    /// no longer matches any known event is shown as missing rather than silently cleared.</para>
+    /// </remarks>
+    [Serializable]
+    public struct EventRef : IEquatable<EventRef>
+    {
+        [SerializeField] private string _eventName;
+
+        /// <summary>Creates a reference to an already-projected event name.</summary>
+        public EventRef(string eventName)
+        {
+            _eventName = eventName;
+        }
+
+        /// <summary>The projected event name, or <see langword="null"/>/empty when unset.</summary>
+        public string Name => _eventName;
+
+        /// <summary>True when no event has been chosen.</summary>
+        public bool IsEmpty => string.IsNullOrEmpty(_eventName);
+
+        /// <summary>Creates a reference from an enum member, using the same projection the publisher uses.</summary>
+        public static EventRef For<T>(T eventEnum) where T : Enum
+        {
+            return new EventRef(EventsFor<T>.GetEventName(eventEnum));
+        }
+
+        /// <summary>
+        /// Recovers the enum value this reference points at, when it belongs to <typeparamref name="T"/>.
+        /// </summary>
+        public bool TryGetEnum<T>(out T eventEnum) where T : Enum
+        {
+            return EventsFor<T>.TryGetEnum(_eventName, out eventEnum);
+        }
+
+        public bool Equals(EventRef other) => string.Equals(_eventName, other._eventName, StringComparison.Ordinal);
+        public override bool Equals(object obj) => obj is EventRef other && Equals(other);
+        public override int GetHashCode() => _eventName == null ? 0 : _eventName.GetHashCode();
+        public override string ToString() => _eventName ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Turns a <see cref="string"/> field holding an event name into the same Inspector dropdown that
+    /// <see cref="EventRef"/> uses, without changing how the field is serialized.
+    /// </summary>
+    /// <remarks>
+    /// <para>Prefer this over converting an existing <c>[SerializeField] string</c> to
+    /// <see cref="EventRef"/>. Changing a field's type changes its serialized shape, so Unity cannot
+    /// carry the old value across and every name already baked into a <c>.unity</c> or <c>.prefab</c>
+    /// asset would be lost and have to be re-picked by hand. Adding this attribute leaves the field a
+    /// string, so existing values keep working and only the authoring experience changes.</para>
+    /// <para>Use <see cref="EventRef"/> for new fields, where there is nothing to migrate.</para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// [EventName] [SerializeField] private string _eventToFire;
+    /// </code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Field, Inherited = true, AllowMultiple = false)]
+    public sealed class EventNameAttribute : PropertyAttribute
+    {
+    }
+}

--- a/Runtime/EventRef.cs.meta
+++ b/Runtime/EventRef.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 853ac3b81d164654a8a4567a548a87fb

--- a/Runtime/EventsDiagnostics.cs
+++ b/Runtime/EventsDiagnostics.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// Records events that were published before something subscribed to them, so that the
+    /// <see cref="EventDelivery.Sticky"/> candidates in a project can be read off observed behaviour
+    /// rather than guessed at.
+    /// </summary>
+    /// <remarks>
+    /// <para>This exists for the migration. Deciding edge-versus-level for every event in a project is
+    /// the expensive part of adopting delivery policies, and most of it is guesswork until something
+    /// says which events actually had late subscribers. A late subscriber to a
+    /// <see cref="EventDelivery.Transient"/> event is precisely the symptom that the hand-maintained
+    /// <c>bool</c> mirrors exist to work around.</para>
+    /// <para><b>It is a heuristic, not a proof.</b> It reports that a subscribe happened after a
+    /// publish, which is evidence of a missed delivery but not of one that mattered — an event may be
+    /// genuinely transient and its late subscriber genuinely uninterested in the earlier occurrence. A
+    /// resubscribe after an unsubscribe counts as late, too. Read the output as a list of events worth
+    /// examining, ranked by how often it happened.</para>
+    /// <para>Off outside the editor and development builds, and the recording is skipped entirely when
+    /// <see cref="Enabled"/> is false, so it costs a bool test per publish in a shipped game.</para>
+    /// </remarks>
+    public static class EventsDiagnostics
+    {
+        /// <summary>
+        /// Whether late deliveries are recorded. Defaults to on in the editor and development builds.
+        /// </summary>
+        public static bool Enabled { get; set; } =
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            true;
+#else
+            false;
+#endif
+
+        /// <summary>What was observed for one event.</summary>
+        public readonly struct Observation
+        {
+            /// <summary>The event this describes.</summary>
+            public readonly EventId EventId;
+
+            /// <summary>How many times it was published.</summary>
+            public readonly int Publishes;
+
+            /// <summary>
+            /// How many subscribes arrived after it had already been published and were delivered
+            /// nothing, because its policy retains nothing.
+            /// </summary>
+            public readonly int LateSubscribes;
+
+            internal Observation(EventId eventId, int publishes, int lateSubscribes)
+            {
+                EventId = eventId;
+                Publishes = publishes;
+                LateSubscribes = lateSubscribes;
+            }
+
+            /// <summary>The event name, for display.</summary>
+            public string Name => EventId.Name;
+        }
+
+        private sealed class Counts
+        {
+            public int Publishes;
+            public int LateSubscribes;
+        }
+
+        private static readonly Dictionary<EventId, Counts> _counts = new Dictionary<EventId, Counts>();
+
+        /// <summary>Notes a publish. Called once per publish, not once per publisher frame.</summary>
+        internal static void NotePublish(EventId eventId)
+        {
+            if (!Enabled || !eventId.IsValid) return;
+            Get(eventId).Publishes++;
+        }
+
+        /// <summary>
+        /// Notes a subscribe to an event that retains nothing, which is a missed delivery only if that
+        /// event has already been published.
+        /// </summary>
+        internal static void NoteTransientSubscribe(EventId eventId)
+        {
+            if (!Enabled || !eventId.IsValid) return;
+            if (!_counts.TryGetValue(eventId, out Counts counts) || counts.Publishes == 0) return;
+            counts.LateSubscribes++;
+        }
+
+        private static Counts Get(EventId eventId)
+        {
+            if (!_counts.TryGetValue(eventId, out Counts counts))
+            {
+                counts = new Counts();
+                _counts[eventId] = counts;
+            }
+            return counts;
+        }
+
+        /// <summary>
+        /// Every event that had at least one late subscriber, most affected first.
+        /// </summary>
+        /// <remarks>These are the events to examine for <see cref="EventDelivery.Sticky"/>. An event
+        /// here is one whose subscribers are demonstrably arriving too late to hear it.</remarks>
+        public static List<Observation> GetLateDeliveries()
+        {
+            var results = new List<Observation>();
+            foreach (KeyValuePair<EventId, Counts> entry in _counts)
+            {
+                if (entry.Value.LateSubscribes > 0)
+                    results.Add(new Observation(entry.Key, entry.Value.Publishes, entry.Value.LateSubscribes));
+            }
+            results.Sort((a, b) => b.LateSubscribes.CompareTo(a.LateSubscribes));
+            return results;
+        }
+
+        /// <summary>Everything observed, including events with no late subscriber.</summary>
+        public static List<Observation> GetAll()
+        {
+            var results = new List<Observation>();
+            foreach (KeyValuePair<EventId, Counts> entry in _counts)
+                results.Add(new Observation(entry.Key, entry.Value.Publishes, entry.Value.LateSubscribes));
+            results.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
+            return results;
+        }
+
+        /// <summary>Discards everything recorded so far.</summary>
+        /// <remarks>Call before a run whose behaviour you want to read in isolation — the interesting
+        /// measurement is usually one boot sequence, not an editor session's accumulated noise.</remarks>
+        public static void Reset()
+        {
+            _counts.Clear();
+        }
+    }
+}

--- a/Runtime/EventsDiagnostics.cs.meta
+++ b/Runtime/EventsDiagnostics.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8a69a4b6c2a6418c893d4a0fbb0b0e76

--- a/Runtime/EventsFor.cs
+++ b/Runtime/EventsFor.cs
@@ -105,6 +105,19 @@ namespace CrawfisSoftware.Events
         }
 
         /// <summary>
+        /// Retrieves the most recently retained value for <paramref name="eventEnum"/>, without
+        /// subscribing to it.
+        /// </summary>
+        /// <remarks>Only events declared <see cref="EventDelivery.Sticky"/> or
+        /// <see cref="EventDelivery.Replay"/> retain anything. Subscribers do not need this — a
+        /// subscription to a retaining event is delivered the retained value immediately, so this is
+        /// for code that wants the current value but has no reason to subscribe.</remarks>
+        public static bool TryGetLast(T eventEnum, out object sender, out object data)
+        {
+            return Facade.TryGetLast(eventEnum, out sender, out data);
+        }
+
+        /// <summary>
         /// Gets the published event name for <paramref name="eventEnum"/>.
         /// </summary>
         public static string GetEventName(T eventEnum)

--- a/Runtime/EventsFor.cs
+++ b/Runtime/EventsFor.cs
@@ -129,6 +129,28 @@ namespace CrawfisSoftware.Events
         }
 
         /// <summary>
+        /// Gets the identity for <paramref name="eventEnum"/> typed to the payload it carries, so that
+        /// publishing and subscribing through it are checked by the compiler.
+        /// </summary>
+        /// <remarks>
+        /// <para>Assign the result to a <c>static readonly</c> field and use that field everywhere. The
+        /// one runtime check — <typeparamref name="TData"/> against the member's
+        /// <see cref="EventPayloadAttribute"/> — then happens once, at type initialization, and every
+        /// call site downstream of it is checked at compile time instead.</para>
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// private static readonly EventId&lt;PlayerFailedData&gt; Failed =
+        ///     EventsFor&lt;TempleRunEvents&gt;.Id&lt;PlayerFailedData&gt;(TempleRunEvents.PlayerFailed);
+        /// </code>
+        /// </example>
+        /// <typeparam name="TData">The payload type, matching the member's <see cref="EventPayloadAttribute"/>.</typeparam>
+        public static EventId<TData> Id<TData>(T eventEnum)
+        {
+            return Facade.GetEventId<TData>(eventEnum);
+        }
+
+        /// <summary>
         /// Gets the published event name for <paramref name="eventEnum"/>.
         /// </summary>
         public static string GetEventName(T eventEnum)

--- a/Runtime/EventsFor.cs
+++ b/Runtime/EventsFor.cs
@@ -1,0 +1,126 @@
+using System;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// Static, enum-typed entry point to the events publisher. One closed type per enum family:
+    /// <c>EventsFor&lt;GameFlowEvents&gt;.Publish(GameFlowEvents.GameStarting, this, null)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Why this exists.</b> <see cref="EventsPublisherEnumsSingleton{T}"/> requires a
+    /// GameObject in a scene, and that requirement is itself a source of ordering bugs under additive
+    /// scene loading. Its <c>Instance</c> is assigned in <c>Awake</c>, so consumers must run later —
+    /// which is what <c>[DefaultExecutionOrder(-10000)]</c> on the concrete subclasses is for. That
+    /// attribute orders <c>Awake</c> calls <em>within a scene load batch</em>, and an additively-loaded
+    /// scene is a separate batch, so a scene loaded before the one hosting the singleton will
+    /// <c>NullReferenceException</c> on <c>Instance</c>.</para>
+    /// <para>Nothing about mapping an enum onto event names needs a scene object. Initialization here
+    /// is lazy and static, so the race cannot occur: any publish or subscribe goes through this type,
+    /// which registers every member of <typeparamref name="T"/> on first touch. Registration therefore
+    /// always precedes the first use, with no execution-order attribute and no scene setup.</para>
+    /// <para>The one case lazy initialization does not cover is an event name reaching the publisher as
+    /// a raw string without this facade ever being touched. Mark the enum with
+    /// <see cref="EventEnumAttribute"/> to have it registered before any scene loads.</para>
+    /// </remarks>
+    /// <typeparam name="T">The enum type identifying this family of events.</typeparam>
+    public static class EventsFor<T> where T : Enum
+    {
+        private static EventsPublisherEnums<T> _facade;
+
+        private static EventsPublisherEnums<T> Facade
+        {
+            get
+            {
+                if (_facade == null)
+                {
+                    // Assigned before registering so that anything reached during registration which
+                    // calls back into this type sees the facade rather than recursing.
+                    _facade = new EventsPublisherEnums<T>(EventsPublisher.Instance);
+                    EventsRegistry.AddResetHandler(Reset);
+                    _facade.RegisterKnownEvents();
+                }
+                return _facade;
+            }
+        }
+
+        /// <summary>
+        /// Registers every member of <typeparamref name="T"/> if that has not happened yet.
+        /// </summary>
+        /// <remarks>Rarely needed directly — publishing or subscribing does this implicitly. Call it to
+        /// register the family ahead of a raw-string publish, or mark the enum with
+        /// <see cref="EventEnumAttribute"/> to have it called automatically before the first scene loads.</remarks>
+        public static void EnsureRegistered()
+        {
+            _ = Facade;
+        }
+
+        private static void Reset()
+        {
+            _facade = null;
+        }
+
+        /// <summary>
+        /// Publishes <paramref name="eventEnum"/> to its subscribers.
+        /// </summary>
+        public static void Publish(T eventEnum, object sender, object data)
+        {
+            Facade.PublishEvent(eventEnum, sender, data);
+        }
+
+        /// <summary>
+        /// Subscribes <paramref name="callback"/> to a single event.
+        /// </summary>
+        public static void Subscribe(T eventEnum, Action<string, object, object> callback)
+        {
+            Facade.SubscribeToEvent(eventEnum, callback);
+        }
+
+        /// <summary>
+        /// Unsubscribes <paramref name="callback"/> from a single event.
+        /// </summary>
+        public static void Unsubscribe(T eventEnum, Action<string, object, object> callback)
+        {
+            Facade.UnsubscribeToEvent(eventEnum, callback);
+        }
+
+        /// <summary>
+        /// Subscribes <paramref name="callback"/> to every member of <typeparamref name="T"/>.
+        /// </summary>
+        /// <remarks>This is scoped to this enum family. For a genuinely global observer — a logger or
+        /// event recorder — use <see cref="IEventsPublisher{T}.SubscribeToAllEvents"/> on
+        /// <see cref="EventsPublisher.Instance"/> instead, which sees every event from every family.</remarks>
+        public static void SubscribeToAll(Action<string, object, object> callback)
+        {
+            foreach (T eventEnum in Enum.GetValues(typeof(T)))
+                Facade.SubscribeToEvent(eventEnum, callback);
+        }
+
+        /// <summary>
+        /// Unsubscribes <paramref name="callback"/> from every member of <typeparamref name="T"/>.
+        /// </summary>
+        public static void UnsubscribeFromAll(Action<string, object, object> callback)
+        {
+            foreach (T eventEnum in Enum.GetValues(typeof(T)))
+                Facade.UnsubscribeToEvent(eventEnum, callback);
+        }
+
+        /// <summary>
+        /// Gets the published event name for <paramref name="eventEnum"/>.
+        /// </summary>
+        public static string GetEventName(T eventEnum)
+        {
+            return Facade.GetEventName(eventEnum);
+        }
+
+        /// <summary>
+        /// Recovers the enum value for a published event name, without allocating.
+        /// </summary>
+        /// <remarks>Use this in an "all events" handler instead of slicing the name on '/' and calling
+        /// <see cref="Enum.Parse(Type, string)"/>, which allocates a string and does a reflection-backed
+        /// lookup on every published event.</remarks>
+        public static bool TryGetEnum(string eventName, out T eventEnum)
+        {
+            return Facade.TryGetEnum(eventName, out eventEnum);
+        }
+    }
+}

--- a/Runtime/EventsFor.cs
+++ b/Runtime/EventsFor.cs
@@ -118,6 +118,17 @@ namespace CrawfisSoftware.Events
         }
 
         /// <summary>
+        /// Gets the interned identity for <paramref name="eventEnum"/>, resolved once at construction.
+        /// </summary>
+        /// <remarks>Hold this to publish or subscribe without the publisher looking the name up. The
+        /// enum path already uses it internally, so this is for code that wants to pass the identity
+        /// around rather than the enum.</remarks>
+        public static EventId GetEventId(T eventEnum)
+        {
+            return Facade.GetEventId(eventEnum);
+        }
+
+        /// <summary>
         /// Gets the published event name for <paramref name="eventEnum"/>.
         /// </summary>
         public static string GetEventName(T eventEnum)

--- a/Runtime/EventsFor.cs.meta
+++ b/Runtime/EventsFor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e57de9bcc0d2488b8748d8375449bd93

--- a/Runtime/EventsPublisher.cs
+++ b/Runtime/EventsPublisher.cs
@@ -75,6 +75,8 @@ namespace CrawfisSoftware.Events
         private void PublishResolved(EventId eventId, string eventName, object sender, object data)
         {
             if (StrictMode) WarnIfPayloadMismatch(eventId, eventName, sender, data);
+            // Here rather than in the frames below, so one publish counts once however deep the stack is.
+            EventsDiagnostics.NotePublish(eventId);
 
             // Dispatch to every frame so subscribers underneath still hear it, but retain only on the
             // frame that is top at publish time. A Stack<T> enumerates top-down, so the first is Peek().

--- a/Runtime/EventsPublisher.cs
+++ b/Runtime/EventsPublisher.cs
@@ -14,6 +14,19 @@ namespace CrawfisSoftware.Events
         /// </summary>
         public static IStackEventsPublisher<string> Instance { get; private set; }
 
+        /// <summary>
+        /// When enabled, publishing an event name that no publisher in the stack has registered is
+        /// reported as an error. Without this, a misspelled name silently reaches no subscriber while
+        /// still notifying "all events" subscribers, so the logger prints it and the system looks healthy.
+        /// Defaults to enabled in the editor and in development builds.
+        /// </summary>
+        public static bool StrictMode { get; set; } =
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            true;
+#else
+            false;
+#endif
+
         static EventsPublisher()
         {
             Instance = new EventsPublisher();
@@ -48,7 +61,29 @@ namespace CrawfisSoftware.Events
         /// <inheritdoc/>
         public void PublishEvent(string eventName, object sender, object data)
         {
+            if (StrictMode) WarnIfUnregistered(eventName, sender);
             foreach (IEventsPublisher<string> publisher in _eventsPublishers) { publisher.PublishEvent(eventName, sender, data); }
+        }
+
+        /// <summary>
+        /// Reports a publish of an event name that no frame in the stack has registered. Checked across
+        /// the whole stack, since <see cref="RegisterEvent"/> only registers with the top frame.
+        /// </summary>
+        private void WarnIfUnregistered(string eventName, object sender)
+        {
+            if (string.IsNullOrEmpty(eventName))
+            {
+                UnityEngine.Debug.LogError($"EventsPublisher: published a null or empty event name from {sender}.");
+                return;
+            }
+            foreach (IEventsPublisher<string> publisher in _eventsPublishers)
+            {
+                if (publisher is EventsPublisherInternal internalPublisher && internalPublisher.IsEventRegistered(eventName))
+                    return;
+            }
+            UnityEngine.Debug.LogError(
+                $"EventsPublisher: '{eventName}' was published by {sender} but is not registered, so no subscriber will receive it. " +
+                "Check for a misspelled event name. Set EventsPublisher.StrictMode = false to silence this.");
         }
 
         /// <inheritdoc/>

--- a/Runtime/EventsPublisher.cs
+++ b/Runtime/EventsPublisher.cs
@@ -74,6 +74,8 @@ namespace CrawfisSoftware.Events
 
         private void PublishResolved(EventId eventId, string eventName, object sender, object data)
         {
+            if (StrictMode) WarnIfPayloadMismatch(eventId, eventName, sender, data);
+
             // Dispatch to every frame so subscribers underneath still hear it, but retain only on the
             // frame that is top at publish time. A Stack<T> enumerates top-down, so the first is Peek().
             bool isTopFrame = true;
@@ -137,6 +139,30 @@ namespace CrawfisSoftware.Events
             UnityEngine.Debug.LogError(
                 $"EventsPublisher: '{eventName}' was published by {sender} but is not registered, so no subscriber will receive it. " +
                 "Check for a misspelled event name. Set EventsPublisher.StrictMode = false to silence this.");
+        }
+
+        /// <summary>
+        /// Reports a publish whose payload is not what the event declared it carries.
+        /// </summary>
+        /// <remarks>
+        /// <para>A publish through <see cref="EventId{TData}"/> cannot be wrong — the compiler saw to
+        /// that — so this exists for the publishes that are still untyped: a raw string, an
+        /// Inspector-authored <see cref="EventRef"/>, or an enum published through the erased overload.
+        /// Those are the ones that can hand a typed subscriber something it cannot use.</para>
+        /// <para>Reported at the publisher, naming the sender, rather than once per subscriber. The
+        /// wrapper around a typed handler reports the same mismatch, but by then the publisher is gone
+        /// and the message can only say which handler was skipped, not who is at fault.</para>
+        /// <para>Costs one dictionary lookup per publish, and only in <see cref="StrictMode"/>.</para>
+        /// </remarks>
+        private void WarnIfPayloadMismatch(EventId eventId, string eventName, object sender, object data)
+        {
+            if (EventsRegistry.IsPayloadAssignable(eventId, data, out Type declared)) return;
+
+            string actual = data == null ? "null" : data.GetType().FullName;
+            UnityEngine.Debug.LogError(
+                $"EventsPublisher: '{eventName}' was published by {sender} with a payload of {actual}, but it is " +
+                $"declared to carry {declared.FullName}. Subscribers typed to that payload will be skipped. " +
+                "Set EventsPublisher.StrictMode = false to silence this.");
         }
 
         /// <inheritdoc/>

--- a/Runtime/EventsPublisher.cs
+++ b/Runtime/EventsPublisher.cs
@@ -7,7 +7,7 @@ namespace CrawfisSoftware.Events
     /// The EventsPublisher is a singleton that manages event publishing and subscription.
     /// It allows for nested publishers, enabling a stack-like behavior for event management.
     /// </summary>
-    public class EventsPublisher : IStackEventsPublisher<string>
+    public class EventsPublisher : IStackEventsPublisher<string>, IEventIdPublisher
     {
         /// <summary>
         /// Gets the singleton instance of the <see cref="IStackEventsPublisher{T}"/> for publishing stack events.
@@ -62,18 +62,60 @@ namespace CrawfisSoftware.Events
         public void PublishEvent(string eventName, object sender, object data)
         {
             if (StrictMode) WarnIfUnregistered(eventName, sender);
+            PublishResolved(EventsRegistry.Intern(eventName), eventName, sender, data);
+        }
 
+        /// <inheritdoc/>
+        public void PublishEvent(EventId eventId, object sender, object data)
+        {
+            if (StrictMode) WarnIfUnregistered(eventId.Name, sender);
+            PublishResolved(eventId, eventId.Name, sender, data);
+        }
+
+        private void PublishResolved(EventId eventId, string eventName, object sender, object data)
+        {
             // Dispatch to every frame so subscribers underneath still hear it, but retain only on the
             // frame that is top at publish time. A Stack<T> enumerates top-down, so the first is Peek().
             bool isTopFrame = true;
             foreach (IEventsPublisher<string> publisher in _eventsPublishers)
             {
                 if (publisher is EventsPublisherInternal internalPublisher)
-                    internalPublisher.PublishEvent(eventName, sender, data, isTopFrame);
+                    internalPublisher.PublishEvent(eventId, sender, data, isTopFrame);
                 else
                     publisher.PublishEvent(eventName, sender, data);
                 isTopFrame = false;
             }
+        }
+
+        /// <inheritdoc/>
+        public void RegisterEvent(EventId eventId)
+        {
+            if (_eventsPublishers.Peek() is IEventIdPublisher idPublisher) idPublisher.RegisterEvent(eventId);
+        }
+
+        /// <inheritdoc/>
+        public void SubscribeToEvent(EventId eventId, Action<string, object, object> callback)
+        {
+            if (_eventsPublishers.Peek() is IEventIdPublisher idPublisher) idPublisher.SubscribeToEvent(eventId, callback);
+        }
+
+        /// <inheritdoc/>
+        public void UnsubscribeToEvent(EventId eventId, Action<string, object, object> callback)
+        {
+            if (_eventsPublishers.Peek() is IEventIdPublisher idPublisher) idPublisher.UnsubscribeToEvent(eventId, callback);
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetLast(EventId eventId, out object sender, out object data)
+        {
+            foreach (IEventsPublisher<string> publisher in _eventsPublishers)
+            {
+                if (publisher is IEventIdPublisher idPublisher && idPublisher.TryGetLast(eventId, out sender, out data))
+                    return true;
+            }
+            sender = null;
+            data = null;
+            return false;
         }
 
         /// <summary>

--- a/Runtime/EventsPublisher.cs
+++ b/Runtime/EventsPublisher.cs
@@ -62,7 +62,18 @@ namespace CrawfisSoftware.Events
         public void PublishEvent(string eventName, object sender, object data)
         {
             if (StrictMode) WarnIfUnregistered(eventName, sender);
-            foreach (IEventsPublisher<string> publisher in _eventsPublishers) { publisher.PublishEvent(eventName, sender, data); }
+
+            // Dispatch to every frame so subscribers underneath still hear it, but retain only on the
+            // frame that is top at publish time. A Stack<T> enumerates top-down, so the first is Peek().
+            bool isTopFrame = true;
+            foreach (IEventsPublisher<string> publisher in _eventsPublishers)
+            {
+                if (publisher is EventsPublisherInternal internalPublisher)
+                    internalPublisher.PublishEvent(eventName, sender, data, isTopFrame);
+                else
+                    publisher.PublishEvent(eventName, sender, data);
+                isTopFrame = false;
+            }
         }
 
         /// <summary>
@@ -90,6 +101,39 @@ namespace CrawfisSoftware.Events
         public void RegisterEvent(string eventName)
         {
             _eventsPublishers.Peek().RegisterEvent(eventName);
+        }
+
+        /// <summary>
+        /// Registers an event and declares its <see cref="EventDelivery"/> policy.
+        /// </summary>
+        /// <remarks>
+        /// <para>The escape hatch for names that no enum can annotate — runtime-computed names, and
+        /// Inspector-authored strings. For an enum family, prefer
+        /// <see cref="EventDeliveryAttribute"/> on the member, which is read before any scene loads and
+        /// keeps the policy next to the event.</para>
+        /// <para>Call this from a static initializer rather than from <c>Awake</c>. The policy must be
+        /// declared before the event is first published, or the first publish — often the one that
+        /// matters most during boot — is not retained.</para>
+        /// <para>First explicit declaration wins; a second, differing one is reported and ignored.</para>
+        /// </remarks>
+        public void RegisterEvent(string eventName, EventDelivery delivery)
+        {
+            EventsRegistry.DeclarePolicy(eventName, delivery);
+            RegisterEvent(eventName);
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>Searches the stack from the top down and returns the first frame holding a
+        /// retained value.</remarks>
+        public bool TryGetLast(string eventName, out object sender, out object data)
+        {
+            foreach (IEventsPublisher<string> publisher in _eventsPublishers)
+            {
+                if (publisher.TryGetLast(eventName, out sender, out data)) return true;
+            }
+            sender = null;
+            data = null;
+            return false;
         }
 
         /// <inheritdoc/>

--- a/Runtime/EventsPublisherEnums.cs
+++ b/Runtime/EventsPublisherEnums.cs
@@ -15,6 +15,11 @@ namespace CrawfisSoftware.Events
     {
         private readonly IEventsPublisher<string> _eventsPublisher;
         private readonly Dictionary<T, string> _eventEnumToStringMap = new Dictionary<T, string>();
+        private readonly Dictionary<string, T> _eventStringToEnumMap = new Dictionary<string, T>();
+
+        // Which enum type has already claimed a given "TypeName/" prefix. Two enum types with the same
+        // simple name (in different namespaces) project onto the same event names and would collide.
+        private static readonly Dictionary<string, Type> _claimedPrefixes = new Dictionary<string, Type>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventsPublisherEnums"/> class with the specified events Enum/EnumName
@@ -28,10 +33,60 @@ namespace CrawfisSoftware.Events
             _eventsPublisher = eventsPublisher;
             var enumType = typeof(T);
             string enumName = enumType.Name;
+            WarnOnPrefixCollision(enumName, enumType);
             foreach (T eventEnum in Enum.GetValues(typeof(T)))
             {
-                _eventEnumToStringMap[eventEnum] = enumName + "/" + eventEnum.ToString();
+                string eventName = enumName + "/" + eventEnum.ToString();
+                _eventEnumToStringMap[eventEnum] = eventName;
+                _eventStringToEnumMap[eventName] = eventEnum;
             }
+        }
+
+        /// <summary>
+        /// Reports two enum types whose simple names collide. Event names are projected from
+        /// <see cref="Type.Name"/>, not <see cref="Type.FullName"/>, so two same-named enums in different
+        /// namespaces would silently share every event.
+        /// </summary>
+        private static void WarnOnPrefixCollision(string enumName, Type enumType)
+        {
+            if (_claimedPrefixes.TryGetValue(enumName, out Type existing))
+            {
+                if (existing != enumType)
+                {
+                    UnityEngine.Debug.LogError(
+                        $"EventsPublisherEnums: '{enumType.FullName}' and '{existing.FullName}' both project onto the " +
+                        $"event name prefix '{enumName}/'. Their events will collide. Rename one of the enum types.");
+                }
+                return;
+            }
+            _claimedPrefixes[enumName] = enumType;
+        }
+
+        /// <summary>
+        /// Gets the published event name for <paramref name="eventEnum"/>.
+        /// </summary>
+        public string GetEventName(T eventEnum)
+        {
+            return _eventEnumToStringMap[eventEnum];
+        }
+
+        /// <summary>
+        /// Recovers the enum value for a published event name, without allocating.
+        /// </summary>
+        /// <remarks>Use this in "all events" handlers instead of slicing the name and calling
+        /// <see cref="Enum.Parse{T}(string)"/>, which allocates a string and does a reflection-backed
+        /// lookup on every published event.</remarks>
+        /// <param name="eventName">The published event name, e.g. "GameFlowEvents/GameStarting".</param>
+        /// <param name="eventEnum">The matching enum value, or the default when the name is not from this enum.</param>
+        /// <returns><see langword="true"/> if the name belongs to <typeparamref name="T"/>.</returns>
+        public bool TryGetEnum(string eventName, out T eventEnum)
+        {
+            if (string.IsNullOrEmpty(eventName))
+            {
+                eventEnum = default;
+                return false;
+            }
+            return _eventStringToEnumMap.TryGetValue(eventName, out eventEnum);
         }
 
         /// <summary>

--- a/Runtime/EventsPublisherEnums.cs
+++ b/Runtime/EventsPublisherEnums.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace CrawfisSoftware.Events
 {
@@ -36,6 +37,8 @@ namespace CrawfisSoftware.Events
                 _eventEnumToStringMap[eventEnum] = eventName;
                 _eventStringToEnumMap[eventName] = eventEnum;
             }
+            // Before any publish can happen through this facade, so the first publish is retained.
+            DeclareDeliveryPolicies(enumType);
         }
 
         /// <summary>
@@ -117,6 +120,32 @@ namespace CrawfisSoftware.Events
             {
                 _eventsPublisher.RegisterEvent(eventName);
             }
+        }
+
+        /// <summary>
+        /// Reads <see cref="EventDeliveryAttribute"/> off each member of <typeparamref name="T"/> and
+        /// declares the policies.
+        /// </summary>
+        /// <remarks>Done once, here, rather than per publish: the reflection cost is paid at
+        /// construction and the publisher then does a dictionary lookup per event.</remarks>
+        private void DeclareDeliveryPolicies(Type enumType)
+        {
+            foreach (KeyValuePair<T, string> entry in _eventEnumToStringMap)
+            {
+                FieldInfo member = enumType.GetField(entry.Key.ToString(), BindingFlags.Public | BindingFlags.Static);
+                if (member == null) continue;
+                var attribute = (EventDeliveryAttribute)Attribute.GetCustomAttribute(member, typeof(EventDeliveryAttribute));
+                if (attribute == null) continue;
+                EventsRegistry.DeclarePolicy(entry.Value, attribute.Delivery);
+            }
+        }
+
+        /// <summary>
+        /// Returns the most recently retained value for <paramref name="eventEnum"/>, if there is one.
+        /// </summary>
+        public bool TryGetLast(T eventEnum, out object sender, out object data)
+        {
+            return _eventsPublisher.TryGetLast(_eventEnumToStringMap[eventEnum], out sender, out data);
         }
     }
 }

--- a/Runtime/EventsPublisherEnums.cs
+++ b/Runtime/EventsPublisherEnums.cs
@@ -47,7 +47,7 @@ namespace CrawfisSoftware.Events
                 _eventEnumToIdMap[eventEnum] = EventsRegistry.Intern(eventName);
             }
             // Before any publish can happen through this facade, so the first publish is retained.
-            DeclareDeliveryPolicies(enumType);
+            DeclareMemberMetadata(enumType);
         }
 
         /// <summary>
@@ -62,6 +62,19 @@ namespace CrawfisSoftware.Events
         public EventId GetEventId(T eventEnum)
         {
             return _eventEnumToIdMap[eventEnum];
+        }
+
+        /// <summary>
+        /// Gets the identity for <paramref name="eventEnum"/> typed to the payload it carries.
+        /// </summary>
+        /// <remarks>When the member declares an <see cref="EventPayloadAttribute"/>, this is where
+        /// <typeparamref name="TData"/> is checked against it — a mismatch is reported here, once, at
+        /// the point the type argument was written, rather than as a cast failure inside a handler.</remarks>
+        public EventId<TData> GetEventId<TData>(T eventEnum)
+        {
+            EventId eventId = _eventEnumToIdMap[eventEnum];
+            EventsRegistry.DeclarePayload(eventId, typeof(TData));
+            return new EventId<TData>(eventId);
         }
 
         /// <summary>
@@ -138,20 +151,23 @@ namespace CrawfisSoftware.Events
         }
 
         /// <summary>
-        /// Reads <see cref="EventDeliveryAttribute"/> off each member of <typeparamref name="T"/> and
-        /// declares the policies.
+        /// Reads <see cref="EventDeliveryAttribute"/> and <see cref="EventPayloadAttribute"/> off each
+        /// member of <typeparamref name="T"/> and declares what they say.
         /// </summary>
         /// <remarks>Done once, here, rather than per publish: the reflection cost is paid at
         /// construction and the publisher then does a dictionary lookup per event.</remarks>
-        private void DeclareDeliveryPolicies(Type enumType)
+        private void DeclareMemberMetadata(Type enumType)
         {
             foreach (KeyValuePair<T, string> entry in _eventEnumToStringMap)
             {
                 FieldInfo member = enumType.GetField(entry.Key.ToString(), BindingFlags.Public | BindingFlags.Static);
                 if (member == null) continue;
-                var attribute = (EventDeliveryAttribute)Attribute.GetCustomAttribute(member, typeof(EventDeliveryAttribute));
-                if (attribute == null) continue;
-                EventsRegistry.DeclarePolicy(entry.Value, attribute.Delivery);
+
+                var delivery = (EventDeliveryAttribute)Attribute.GetCustomAttribute(member, typeof(EventDeliveryAttribute));
+                if (delivery != null) EventsRegistry.DeclarePolicy(entry.Value, delivery.Delivery);
+
+                var payload = (EventPayloadAttribute)Attribute.GetCustomAttribute(member, typeof(EventPayloadAttribute));
+                if (payload != null) EventsRegistry.DeclarePayload(_eventEnumToIdMap[entry.Key], payload.PayloadType);
             }
         }
 

--- a/Runtime/EventsPublisherEnums.cs
+++ b/Runtime/EventsPublisherEnums.cs
@@ -29,7 +29,7 @@ namespace CrawfisSoftware.Events
         {
             _eventsPublisher = eventsPublisher;
             var enumType = typeof(T);
-            string enumName = enumType.Name;
+            string enumName = EventsRegistry.GetPrefix(enumType);
             EventsRegistry.ClaimPrefix(enumName, enumType);
             foreach (T eventEnum in Enum.GetValues(typeof(T)))
             {

--- a/Runtime/EventsPublisherEnums.cs
+++ b/Runtime/EventsPublisherEnums.cs
@@ -18,6 +18,13 @@ namespace CrawfisSoftware.Events
         private readonly Dictionary<T, string> _eventEnumToStringMap = new Dictionary<T, string>();
         private readonly Dictionary<string, T> _eventStringToEnumMap = new Dictionary<string, T>();
 
+        // Resolved once at construction. Publishing and subscribing through these skips the name lookup
+        // entirely, which is the point of interning.
+        private readonly Dictionary<T, EventId> _eventEnumToIdMap = new Dictionary<T, EventId>();
+
+        // Null when an injected publisher predates IEventIdPublisher; the string path still works.
+        private readonly IEventIdPublisher _idPublisher;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="EventsPublisherEnums"/> class with the specified events Enum/EnumName
         /// publisher.
@@ -28,6 +35,7 @@ namespace CrawfisSoftware.Events
         public EventsPublisherEnums(IEventsPublisher<string> eventsPublisher)
         {
             _eventsPublisher = eventsPublisher;
+            _idPublisher = eventsPublisher as IEventIdPublisher;
             var enumType = typeof(T);
             string enumName = EventsRegistry.GetPrefix(enumType);
             EventsRegistry.ClaimPrefix(enumName, enumType);
@@ -36,6 +44,7 @@ namespace CrawfisSoftware.Events
                 string eventName = enumName + "/" + eventEnum.ToString();
                 _eventEnumToStringMap[eventEnum] = eventName;
                 _eventStringToEnumMap[eventName] = eventEnum;
+                _eventEnumToIdMap[eventEnum] = EventsRegistry.Intern(eventName);
             }
             // Before any publish can happen through this facade, so the first publish is retained.
             DeclareDeliveryPolicies(enumType);
@@ -47,6 +56,12 @@ namespace CrawfisSoftware.Events
         public string GetEventName(T eventEnum)
         {
             return _eventEnumToStringMap[eventEnum];
+        }
+
+        /// <summary>Gets the interned identity for <paramref name="eventEnum"/>.</summary>
+        public EventId GetEventId(T eventEnum)
+        {
+            return _eventEnumToIdMap[eventEnum];
         }
 
         /// <summary>
@@ -78,8 +93,8 @@ namespace CrawfisSoftware.Events
         /// <param name="data">The data associated with the event. This can be any object containing information relevant to the event.</param>
         public void PublishEvent(T eventEnum, object sender, object data)
         {
-            string eventName = _eventEnumToStringMap[eventEnum];
-            _eventsPublisher.PublishEvent(eventName, sender, data);
+            if (_idPublisher != null) _idPublisher.PublishEvent(_eventEnumToIdMap[eventEnum], sender, data);
+            else _eventsPublisher.PublishEvent(_eventEnumToStringMap[eventEnum], sender, data);
         }
 
         /// <summary>
@@ -94,8 +109,8 @@ namespace CrawfisSoftware.Events
         /// an <see cref="object"/>.</param>
         public void SubscribeToEvent(T eventEnum, Action<string, object, object> callback)
         {
-            string eventName = _eventEnumToStringMap[eventEnum];
-            _eventsPublisher.SubscribeToEvent(eventName, callback);
+            if (_idPublisher != null) _idPublisher.SubscribeToEvent(_eventEnumToIdMap[eventEnum], callback);
+            else _eventsPublisher.SubscribeToEvent(_eventEnumToStringMap[eventEnum], callback);
         }
 
         /// <summary>
@@ -108,8 +123,8 @@ namespace CrawfisSoftware.Events
         /// the event is triggered.</param>
         public void UnsubscribeToEvent(T eventEnum, Action<string, object, object> callback)
         {
-            string eventName = _eventEnumToStringMap[eventEnum];
-            _eventsPublisher.UnsubscribeToEvent(eventName, callback);
+            if (_idPublisher != null) _idPublisher.UnsubscribeToEvent(_eventEnumToIdMap[eventEnum], callback);
+            else _eventsPublisher.UnsubscribeToEvent(_eventEnumToStringMap[eventEnum], callback);
         }
 
         internal void RegisterKnownEvents()
@@ -145,6 +160,7 @@ namespace CrawfisSoftware.Events
         /// </summary>
         public bool TryGetLast(T eventEnum, out object sender, out object data)
         {
+            if (_idPublisher != null) return _idPublisher.TryGetLast(_eventEnumToIdMap[eventEnum], out sender, out data);
             return _eventsPublisher.TryGetLast(_eventEnumToStringMap[eventEnum], out sender, out data);
         }
     }

--- a/Runtime/EventsPublisherEnums.cs
+++ b/Runtime/EventsPublisherEnums.cs
@@ -17,10 +17,6 @@ namespace CrawfisSoftware.Events
         private readonly Dictionary<T, string> _eventEnumToStringMap = new Dictionary<T, string>();
         private readonly Dictionary<string, T> _eventStringToEnumMap = new Dictionary<string, T>();
 
-        // Which enum type has already claimed a given "TypeName/" prefix. Two enum types with the same
-        // simple name (in different namespaces) project onto the same event names and would collide.
-        private static readonly Dictionary<string, Type> _claimedPrefixes = new Dictionary<string, Type>();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="EventsPublisherEnums"/> class with the specified events Enum/EnumName
         /// publisher.
@@ -33,33 +29,13 @@ namespace CrawfisSoftware.Events
             _eventsPublisher = eventsPublisher;
             var enumType = typeof(T);
             string enumName = enumType.Name;
-            WarnOnPrefixCollision(enumName, enumType);
+            EventsRegistry.ClaimPrefix(enumName, enumType);
             foreach (T eventEnum in Enum.GetValues(typeof(T)))
             {
                 string eventName = enumName + "/" + eventEnum.ToString();
                 _eventEnumToStringMap[eventEnum] = eventName;
                 _eventStringToEnumMap[eventName] = eventEnum;
             }
-        }
-
-        /// <summary>
-        /// Reports two enum types whose simple names collide. Event names are projected from
-        /// <see cref="Type.Name"/>, not <see cref="Type.FullName"/>, so two same-named enums in different
-        /// namespaces would silently share every event.
-        /// </summary>
-        private static void WarnOnPrefixCollision(string enumName, Type enumType)
-        {
-            if (_claimedPrefixes.TryGetValue(enumName, out Type existing))
-            {
-                if (existing != enumType)
-                {
-                    UnityEngine.Debug.LogError(
-                        $"EventsPublisherEnums: '{enumType.FullName}' and '{existing.FullName}' both project onto the " +
-                        $"event name prefix '{enumName}/'. Their events will collide. Rename one of the enum types.");
-                }
-                return;
-            }
-            _claimedPrefixes[enumName] = enumType;
         }
 
         /// <summary>
@@ -135,9 +111,11 @@ namespace CrawfisSoftware.Events
 
         internal void RegisterKnownEvents()
         {
-            foreach(string eventName in _eventEnumToStringMap.Values)
+            // Registers with the publisher this instance was constructed against, rather than reaching
+            // for EventsPublisher.Instance, so an injected publisher is honoured.
+            foreach (string eventName in _eventEnumToStringMap.Values)
             {
-                EventsPublisher.Instance.RegisterEvent(eventName);
+                _eventsPublisher.RegisterEvent(eventName);
             }
         }
     }

--- a/Runtime/EventsPublisherEnumsSingleton.cs
+++ b/Runtime/EventsPublisherEnumsSingleton.cs
@@ -4,20 +4,39 @@ using UnityEngine;
 
 namespace CrawfisSoftware.Events
 {
+    /// <summary>
+    /// Scene-object entry point to the events publisher for a single enum family.
+    /// </summary>
+    /// <remarks>
+    /// <para>Prefer <see cref="EventsFor{T}"/> for new code. This type requires a GameObject in a
+    /// scene and assigns <see cref="Instance"/> in <c>Awake</c>, so consumers must run later — which is
+    /// what <c>[DefaultExecutionOrder(-10000)]</c> on concrete subclasses is for. That attribute orders
+    /// <c>Awake</c> calls within a scene load batch, and an additively-loaded scene is a separate
+    /// batch, so a scene loaded before the one hosting this singleton will
+    /// <c>NullReferenceException</c> on <see cref="Instance"/>. <see cref="EventsFor{T}"/> is static
+    /// and lazily initialized, so that race cannot occur.</para>
+    /// <para>Every member here now forwards to <see cref="EventsFor{T}"/>, so the two paths share one
+    /// facade and cannot disagree. Existing scene objects keep working unchanged during migration.</para>
+    /// </remarks>
     public class EventsPublisherEnumsSingleton<T> : MonoBehaviour where T : Enum
     {
         public static EventsPublisherEnumsSingleton<T> Instance { get; private set; }
-        private EventsPublisherEnums<T> _eventsPublisher;
+
         private void Awake()
         {
             if (Instance != null && Instance != this)
             {
-                Destroy(Instance);
+                // Destroy the duplicate that just awoke, not the instance already in use.
+                Destroy(this);
                 return;
             }
             Instance = this;
-            _eventsPublisher = new EventsPublisherEnums<T>(EventsPublisher.Instance);
-            _eventsPublisher.RegisterKnownEvents();
+            EventsFor<T>.EnsureRegistered();
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this) Instance = null;
         }
 
         /// <summary>
@@ -28,7 +47,7 @@ namespace CrawfisSoftware.Events
         /// <param name="data">The data associated with the event. This can be any object containing information relevant to the event.</param>
         public void PublishEvent(T eventEnum, object sender, object data)
         {
-            _eventsPublisher.PublishEvent(eventEnum, sender, data);
+            EventsFor<T>.Publish(eventEnum, sender, data);
         }
 
         /// <summary>
@@ -44,7 +63,7 @@ namespace CrawfisSoftware.Events
         /// event.</description></item> </list></param>
         public void SubscribeToEvent(T eventEnum, Action<string, object, object> callback)
         {
-            _eventsPublisher.SubscribeToEvent(eventEnum, callback);
+            EventsFor<T>.Subscribe(eventEnum, callback);
         }
 
         /// <summary>
@@ -57,7 +76,7 @@ namespace CrawfisSoftware.Events
         /// the event is triggered.</param>
         public void UnsubscribeToEvent(T eventEnum, Action<string, object, object> callback)
         {
-            _eventsPublisher.UnsubscribeToEvent(eventEnum, callback);
+            EventsFor<T>.Unsubscribe(eventEnum, callback);
         }
 
         /// <summary>
@@ -65,7 +84,7 @@ namespace CrawfisSoftware.Events
         /// </summary>
         public string GetEventName(T eventEnum)
         {
-            return _eventsPublisher.GetEventName(eventEnum);
+            return EventsFor<T>.GetEventName(eventEnum);
         }
 
         /// <summary>
@@ -75,7 +94,7 @@ namespace CrawfisSoftware.Events
         /// inside an "all events" handler, which allocates a string per published event.</remarks>
         public bool TryGetEnum(string eventName, out T eventEnum)
         {
-            return _eventsPublisher.TryGetEnum(eventName, out eventEnum);
+            return EventsFor<T>.TryGetEnum(eventName, out eventEnum);
         }
         //private static void RegisterKnownEvents()
         //{
@@ -86,22 +105,20 @@ namespace CrawfisSoftware.Events
         //    }
         //}
 
+        /// <summary>
+        /// Subscribes <paramref name="callback"/> to every member of <typeparamref name="T"/>.
+        /// </summary>
         public void SubscribeToAllEnumEvents(Action<string, object, object> callback)
         {
-            foreach (T eventEnum in Enum.GetValues(typeof(T)))
-            {
-                //string eventName = eventEnum.ToString();
-                Instance.SubscribeToEvent(eventEnum, callback);
-            }
+            EventsFor<T>.SubscribeToAll(callback);
         }
 
+        /// <summary>
+        /// Unsubscribes <paramref name="callback"/> from every member of <typeparamref name="T"/>.
+        /// </summary>
         public void UnsubscribeToAllEnumEvents(Action<string, object, object> callback)
         {
-            foreach (T eventEnum in Enum.GetValues(typeof(T)))
-            {
-                //string eventName = eventEnum.ToString();
-                Instance.UnsubscribeToEvent(eventEnum, callback);
-            }
+            EventsFor<T>.UnsubscribeFromAll(callback);
         }
     }
 }

--- a/Runtime/EventsPublisherEnumsSingleton.cs
+++ b/Runtime/EventsPublisherEnumsSingleton.cs
@@ -59,6 +59,24 @@ namespace CrawfisSoftware.Events
         {
             _eventsPublisher.UnsubscribeToEvent(eventEnum, callback);
         }
+
+        /// <summary>
+        /// Gets the published event name for <paramref name="eventEnum"/>.
+        /// </summary>
+        public string GetEventName(T eventEnum)
+        {
+            return _eventsPublisher.GetEventName(eventEnum);
+        }
+
+        /// <summary>
+        /// Recovers the enum value for a published event name, without allocating.
+        /// </summary>
+        /// <remarks>Prefer this over slicing the name on '/' and calling <see cref="Enum.Parse{T}(string)"/>
+        /// inside an "all events" handler, which allocates a string per published event.</remarks>
+        public bool TryGetEnum(string eventName, out T eventEnum)
+        {
+            return _eventsPublisher.TryGetEnum(eventName, out eventEnum);
+        }
         //private static void RegisterKnownEvents()
         //{
         //    foreach (T eventEnum in Enum.GetValues(typeof(T)))

--- a/Runtime/EventsPublisherEnumsSingleton.cs
+++ b/Runtime/EventsPublisherEnumsSingleton.cs
@@ -80,6 +80,15 @@ namespace CrawfisSoftware.Events
         }
 
         /// <summary>
+        /// Retrieves the most recently retained value for <paramref name="eventEnum"/>, without
+        /// subscribing to it. See <see cref="EventsFor{T}.TryGetLast"/>.
+        /// </summary>
+        public bool TryGetLast(T eventEnum, out object sender, out object data)
+        {
+            return EventsFor<T>.TryGetLast(eventEnum, out sender, out data);
+        }
+
+        /// <summary>
         /// Gets the published event name for <paramref name="eventEnum"/>.
         /// </summary>
         public string GetEventName(T eventEnum)

--- a/Runtime/EventsPublisherExtensions.cs
+++ b/Runtime/EventsPublisherExtensions.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// <see cref="EventRef"/> overloads for the publisher, so a component whose event is authored in the
+    /// Inspector never has to reach for the underlying string.
+    /// </summary>
+    /// <remarks>
+    /// <para>Extension methods rather than interface members, so no existing implementer of
+    /// <see cref="IEventsPublisher{T}"/> has to change.</para>
+    /// <para>These exist because the raw-string API cannot be closed off. A component that publishes a
+    /// name chosen in the Inspector is holding that name as data, not as a literal, and must still hand
+    /// a string to the publisher at runtime. The hazard was never the string API itself — it was the
+    /// name being typed by hand with nothing to check it. <see cref="EventRef"/> and
+    /// <see cref="EventNameAttribute"/> close that at the authoring step; these overloads keep the
+    /// call site from having to unwrap the value again.</para>
+    /// </remarks>
+    public static class EventsPublisherExtensions
+    {
+        /// <summary>Publishes the event an <see cref="EventRef"/> points at. Ignored when unset.</summary>
+        public static void PublishEvent(this IEventsPublisher<string> publisher, EventRef eventRef, object sender, object data)
+        {
+            if (publisher == null || eventRef.IsEmpty) return;
+            publisher.PublishEvent(eventRef.Name, sender, data);
+        }
+
+        /// <summary>Subscribes to the event an <see cref="EventRef"/> points at. Ignored when unset.</summary>
+        public static void SubscribeToEvent(this IEventsPublisher<string> publisher, EventRef eventRef, Action<string, object, object> callback)
+        {
+            if (publisher == null || eventRef.IsEmpty) return;
+            publisher.SubscribeToEvent(eventRef.Name, callback);
+        }
+
+        /// <summary>Unsubscribes from the event an <see cref="EventRef"/> points at. Ignored when unset.</summary>
+        /// <remarks>The unset check here is defence in depth rather than the thing that prevents a
+        /// crash — the publisher already rejects null and empty names, so removing this guard changes
+        /// no observable behaviour. It avoids the pointless call, and keeps every overload on this type
+        /// reading the same way.</remarks>
+        public static void UnsubscribeToEvent(this IEventsPublisher<string> publisher, EventRef eventRef, Action<string, object, object> callback)
+        {
+            if (publisher == null || eventRef.IsEmpty) return;
+            publisher.UnsubscribeToEvent(eventRef.Name, callback);
+        }
+
+        /// <summary>Registers the event an <see cref="EventRef"/> points at, with a delivery policy.</summary>
+        public static void RegisterEvent(this IEventsPublisher<string> publisher, EventRef eventRef, EventDelivery delivery)
+        {
+            if (publisher == null || eventRef.IsEmpty) return;
+            publisher.RegisterEvent(eventRef.Name, delivery);
+        }
+
+        /// <summary>Reads the retained value for the event an <see cref="EventRef"/> points at.</summary>
+        public static bool TryGetLast(this IEventsPublisher<string> publisher, EventRef eventRef, out object sender, out object data)
+        {
+            if (publisher == null || eventRef.IsEmpty)
+            {
+                sender = null;
+                data = null;
+                return false;
+            }
+            return publisher.TryGetLast(eventRef.Name, out sender, out data);
+        }
+    }
+}

--- a/Runtime/EventsPublisherExtensions.cs.meta
+++ b/Runtime/EventsPublisherExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a39d24f1f43a4bf8b70dc09fb142f7e3

--- a/Runtime/EventsPublisherInternal.cs
+++ b/Runtime/EventsPublisherInternal.cs
@@ -12,9 +12,28 @@ namespace CrawfisSoftware.Events
         private Queue<(string eventName, Action<string, object, object> callback, object sender, object data)> _callbackQueue
             = new Queue<(string eventName, Action<string, object, object> callback, object sender, object data)>();
 
-        // Guards against a callback that publishes an event starting a second, nested drain of the
-        // shared queue. Nested publishes enqueue and return; the outermost drain processes them.
+        // Guards against a callback that publishes an event, or subscribes to one, starting a second
+        // nested drain of the shared queue. Nested work enqueues and returns; the outermost drain
+        // processes it in order.
         private bool _isDraining;
+
+        // Retained values, per policy. These are per-frame by design: the policy registry is
+        // stack-global, but what was actually published lives in the frame it was published into, so
+        // Pop() discards it.
+        private readonly Dictionary<string, RetainedValue> _stickyValues = new Dictionary<string, RetainedValue>();
+        private readonly Dictionary<string, List<RetainedValue>> _journals = new Dictionary<string, List<RetainedValue>>();
+
+        /// <summary>A published <c>(sender, data)</c> pair held for later delivery.</summary>
+        private readonly struct RetainedValue
+        {
+            public readonly object Sender;
+            public readonly object Data;
+            public RetainedValue(object sender, object data)
+            {
+                Sender = sender;
+                Data = data;
+            }
+        }
 
         public void RegisterEvent(string eventName)
         {
@@ -24,11 +43,108 @@ namespace CrawfisSoftware.Events
                 events.Add(eventName, NullCallback);
             }
         }
+        /// <inheritdoc/>
+        public void RegisterEvent(string eventName, EventDelivery delivery)
+        {
+            EventsRegistry.DeclarePolicy(eventName, delivery);
+            RegisterEvent(eventName);
+        }
+
         public void SubscribeToEvent(string eventName, Action<string, object, object> callback)
         {
             if (string.IsNullOrEmpty(eventName) || callback == null) return;
             RegisterEvent(eventName);
             events[eventName] += callback;
+            ReplayTo(eventName, callback);
+        }
+
+        /// <summary>
+        /// Delivers whatever this frame has retained for <paramref name="eventName"/> to a subscriber
+        /// that has just arrived.
+        /// </summary>
+        /// <remarks>
+        /// <para>Replay is immediate rather than deferred, so a subscriber knows the current state by
+        /// the time <c>Subscribe</c> returns. It fires exactly when the subscriber chose to subscribe,
+        /// which is a moment the subscriber controls — subscribing at the end of <c>Awake</c>, in
+        /// <c>OnEnable</c>, or in <c>Start</c> is sufficient to be fully constructed first.</para>
+        /// <para>It is routed through the same queue as a publish, so a <c>Subscribe</c> made from
+        /// inside a handler — while a drain is already in progress — enqueues and runs in order rather
+        /// than nesting.</para>
+        /// </remarks>
+        private void ReplayTo(string eventName, Action<string, object, object> callback)
+        {
+            switch (EventsRegistry.GetPolicy(eventName))
+            {
+                case EventDelivery.Sticky:
+                    if (_stickyValues.TryGetValue(eventName, out RetainedValue retained))
+                        _callbackQueue.Enqueue((eventName, callback, retained.Sender, retained.Data));
+                    break;
+
+                case EventDelivery.Replay:
+                    if (_journals.TryGetValue(eventName, out List<RetainedValue> journal))
+                        for (int i = 0; i < journal.Count; i++)
+                            _callbackQueue.Enqueue((eventName, callback, journal[i].Sender, journal[i].Data));
+                    break;
+
+                default:
+                    return; // Transient retains nothing.
+            }
+            Drain();
+        }
+
+        /// <summary>
+        /// Records a published value according to the event's delivery policy.
+        /// </summary>
+        private void Retain(string eventName, object sender, object data)
+        {
+            switch (EventsRegistry.GetPolicy(eventName))
+            {
+                case EventDelivery.Sticky:
+                    _stickyValues[eventName] = new RetainedValue(sender, data);
+                    break;
+
+                case EventDelivery.Replay:
+                    if (!_journals.TryGetValue(eventName, out List<RetainedValue> journal))
+                    {
+                        journal = new List<RetainedValue>();
+                        _journals[eventName] = journal;
+                    }
+                    journal.Add(new RetainedValue(sender, data));
+                    // Reported, never truncated: a silent cap would read as "everything was replayed".
+                    if (journal.Count == EventsRegistry.JournalWarningThreshold)
+                    {
+                        UnityEngine.Debug.LogWarning(
+                            $"EventsPublisher: the Replay journal for '{eventName}' has reached " +
+                            $"{EventsRegistry.JournalWarningThreshold} entries and keeps growing. Scope it by " +
+                            "publishing into a pushed publisher frame that is popped when its scene unloads.");
+                    }
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Returns the most recently retained value for <paramref name="eventName"/>, if this frame has one.
+        /// </summary>
+        public bool TryGetLast(string eventName, out object sender, out object data)
+        {
+            if (!string.IsNullOrEmpty(eventName))
+            {
+                if (_stickyValues.TryGetValue(eventName, out RetainedValue retained))
+                {
+                    sender = retained.Sender;
+                    data = retained.Data;
+                    return true;
+                }
+                if (_journals.TryGetValue(eventName, out List<RetainedValue> journal) && journal.Count > 0)
+                {
+                    sender = journal[journal.Count - 1].Sender;
+                    data = journal[journal.Count - 1].Data;
+                    return true;
+                }
+            }
+            sender = null;
+            data = null;
+            return false;
         }
 
         public void UnsubscribeToEvent(string eventName, Action<string, object, object> callback)
@@ -58,7 +174,21 @@ namespace CrawfisSoftware.Events
 
         public void PublishEvent(string eventName, object sender, object data)
         {
+            PublishEvent(eventName, sender, data, retain: true);
+        }
+
+        /// <summary>
+        /// Dispatches an event, optionally recording it under this frame's delivery policy.
+        /// </summary>
+        /// <remarks>The stack dispatches every publish to every frame so that subscribers on lower
+        /// frames still hear it, but retains only on the frame that was top at publish time. Retaining
+        /// on every frame would mean <c>Pop()</c> discarded nothing, since the value would also be
+        /// sitting in the frames underneath.</remarks>
+        internal void PublishEvent(string eventName, object sender, object data, bool retain)
+        {
             if (string.IsNullOrEmpty(eventName)) return;
+
+            if (retain) Retain(eventName, sender, data);
 
             if (events.TryGetValue(eventName, out Action<string, object, object> eventDelegate))
             {
@@ -72,8 +202,17 @@ namespace CrawfisSoftware.Events
             foreach (var handler in allSubscribers)
                 _callbackQueue.Enqueue((eventName, handler, sender, data));
 
-            // A nested publish (a callback publishing an event) only enqueues. The outermost call owns
-            // the drain, so the remaining callbacks for the *current* event run first, as intended.
+            Drain();
+        }
+
+        /// <summary>
+        /// Invokes queued callbacks until the queue is empty.
+        /// </summary>
+        /// <remarks>Nested work — a callback that publishes an event, or subscribes to one and
+        /// triggers a replay — only enqueues. The outermost call owns the drain, so the remaining
+        /// callbacks for the <em>current</em> event run first, as intended.</remarks>
+        private void Drain()
+        {
             if (_isDraining) return;
 
             _isDraining = true;
@@ -131,6 +270,8 @@ namespace CrawfisSoftware.Events
         {
             events.Clear();
             allSubscribers.Clear();
+            _stickyValues.Clear();
+            _journals.Clear();
         }
     }
 }

--- a/Runtime/EventsPublisherInternal.cs
+++ b/Runtime/EventsPublisherInternal.cs
@@ -9,10 +9,16 @@ namespace CrawfisSoftware.Events
         // Define the events that occur in the game
         private readonly Dictionary<string, Action<string, object, object>> events = new Dictionary<string, Action<string, object, object>>();
         private readonly List<Action<string, object, object>> allSubscribers = new List<Action<string, object, object>>();
-        private Queue<(string eventName, Delegate callback, object sender, object data)> _callbackQueue = new Queue<(string eventName, Delegate callback, object sender, object data)>();
+        private Queue<(string eventName, Action<string, object, object> callback, object sender, object data)> _callbackQueue
+            = new Queue<(string eventName, Action<string, object, object> callback, object sender, object data)>();
+
+        // Guards against a callback that publishes an event starting a second, nested drain of the
+        // shared queue. Nested publishes enqueue and return; the outermost drain processes them.
+        private bool _isDraining;
 
         public void RegisterEvent(string eventName)
         {
+            if (string.IsNullOrEmpty(eventName)) return;
             if (!events.ContainsKey(eventName))
             {
                 events.Add(eventName, NullCallback);
@@ -20,15 +26,24 @@ namespace CrawfisSoftware.Events
         }
         public void SubscribeToEvent(string eventName, Action<string, object, object> callback)
         {
+            if (string.IsNullOrEmpty(eventName) || callback == null) return;
             RegisterEvent(eventName);
-            if (events.ContainsKey(eventName) && callback != null)
-                events[eventName] += callback;
+            events[eventName] += callback;
         }
 
         public void UnsubscribeToEvent(string eventName, Action<string, object, object> callback)
         {
-            if (events.ContainsKey(eventName) && callback != null)
+            if (string.IsNullOrEmpty(eventName) || callback == null) return;
+            if (events.ContainsKey(eventName))
                 events[eventName] -= callback;
+        }
+
+        /// <summary>
+        /// Returns true if <paramref name="eventName"/> has been registered with this publisher.
+        /// </summary>
+        internal bool IsEventRegistered(string eventName)
+        {
+            return !string.IsNullOrEmpty(eventName) && events.ContainsKey(eventName);
         }
 
         public void SubscribeToAllEvents(Action<string, object, object> callback)
@@ -43,33 +58,47 @@ namespace CrawfisSoftware.Events
 
         public void PublishEvent(string eventName, object sender, object data)
         {
+            if (string.IsNullOrEmpty(eventName)) return;
+
             if (events.TryGetValue(eventName, out Action<string, object, object> eventDelegate))
             {
-                //eventDelegate(sender, data);
                 var callbacks = eventDelegate.GetInvocationList();
 
                 // Queue up each callback. This ensures that if a callback publishes an event, that the
                 // other callbacks for *this* event are called before the newly published event's callbacks.
                 foreach (var callback in callbacks)
-                    _callbackQueue.Enqueue((eventName, callback, sender, data));
+                    _callbackQueue.Enqueue((eventName, (Action<string, object, object>)callback, sender, data));
             }
             foreach (var handler in allSubscribers)
                 _callbackQueue.Enqueue((eventName, handler, sender, data));
-            //handler(eventName, sender, data);
 
-            while (_callbackQueue.Count > 0)
+            // A nested publish (a callback publishing an event) only enqueues. The outermost call owns
+            // the drain, so the remaining callbacks for the *current* event run first, as intended.
+            if (_isDraining) return;
+
+            _isDraining = true;
+            try
             {
-                var message = _callbackQueue.Dequeue();
-                eventName = message.eventName;
-                var callback = message.callback;
-                try
+                while (_callbackQueue.Count > 0)
                 {
-                    callback.DynamicInvoke(eventName, message.sender, message.data);
+                    var message = _callbackQueue.Dequeue();
+                    Action<string, object, object> callback = message.callback;
+                    try
+                    {
+                        callback(message.eventName, message.sender, message.data);
+                    }
+                    catch (Exception e)
+                    {
+                        UnityEngine.Debug.LogError(
+                            $"Exception publishing {message.eventName} to {callback.Target}: {e}");
+                    }
                 }
-                catch (Exception e)
-                {
-                    UnityEngine.Debug.LogError($"Exception publishing {message.eventName}: {callback.Target} {e.InnerException.Message} {e.InnerException.StackTrace} {e.InnerException.Source}");
-                }
+            }
+            finally
+            {
+                // Never leave stale callbacks queued; they would otherwise flush during an unrelated publish.
+                _callbackQueue.Clear();
+                _isDraining = false;
             }
         }
 

--- a/Runtime/EventsPublisherInternal.cs
+++ b/Runtime/EventsPublisherInternal.cs
@@ -102,7 +102,11 @@ namespace CrawfisSoftware.Events
                     break;
 
                 default:
-                    return; // Transient retains nothing.
+                    // Transient retains nothing, so a subscriber arriving after this event has already
+                    // been published hears nothing. That is the symptom the bool mirrors exist to work
+                    // around, and the migration wants it counted rather than guessed at.
+                    EventsDiagnostics.NoteTransientSubscribe(eventId);
+                    return;
             }
             Drain();
         }

--- a/Runtime/EventsPublisherInternal.cs
+++ b/Runtime/EventsPublisherInternal.cs
@@ -4,10 +4,12 @@ using System.Linq;
 
 namespace CrawfisSoftware.Events
 {
-    internal class EventsPublisherInternal : IEventsPublisher<string>
+    internal class EventsPublisherInternal : IEventsPublisher<string>, IEventIdPublisher
     {
         // Define the events that occur in the game
-        private readonly Dictionary<string, Action<string, object, object>> events = new Dictionary<string, Action<string, object, object>>();
+        // Keyed on the interned EventId rather than the name: an int compare per lookup instead of a
+        // string hash, and the name is still what every callback receives.
+        private readonly Dictionary<EventId, Action<string, object, object>> events = new Dictionary<EventId, Action<string, object, object>>();
         private readonly List<Action<string, object, object>> allSubscribers = new List<Action<string, object, object>>();
         private Queue<(string eventName, Action<string, object, object> callback, object sender, object data)> _callbackQueue
             = new Queue<(string eventName, Action<string, object, object> callback, object sender, object data)>();
@@ -20,8 +22,8 @@ namespace CrawfisSoftware.Events
         // Retained values, per policy. These are per-frame by design: the policy registry is
         // stack-global, but what was actually published lives in the frame it was published into, so
         // Pop() discards it.
-        private readonly Dictionary<string, RetainedValue> _stickyValues = new Dictionary<string, RetainedValue>();
-        private readonly Dictionary<string, List<RetainedValue>> _journals = new Dictionary<string, List<RetainedValue>>();
+        private readonly Dictionary<EventId, RetainedValue> _stickyValues = new Dictionary<EventId, RetainedValue>();
+        private readonly Dictionary<EventId, List<RetainedValue>> _journals = new Dictionary<EventId, List<RetainedValue>>();
 
         /// <summary>A published <c>(sender, data)</c> pair held for later delivery.</summary>
         private readonly struct RetainedValue
@@ -37,10 +39,16 @@ namespace CrawfisSoftware.Events
 
         public void RegisterEvent(string eventName)
         {
-            if (string.IsNullOrEmpty(eventName)) return;
-            if (!events.ContainsKey(eventName))
+            RegisterEvent(EventsRegistry.Intern(eventName));
+        }
+
+        /// <inheritdoc/>
+        public void RegisterEvent(EventId eventId)
+        {
+            if (!eventId.IsValid) return;
+            if (!events.ContainsKey(eventId))
             {
-                events.Add(eventName, NullCallback);
+                events.Add(eventId, NullCallback);
             }
         }
         /// <inheritdoc/>
@@ -52,10 +60,16 @@ namespace CrawfisSoftware.Events
 
         public void SubscribeToEvent(string eventName, Action<string, object, object> callback)
         {
-            if (string.IsNullOrEmpty(eventName) || callback == null) return;
-            RegisterEvent(eventName);
-            events[eventName] += callback;
-            ReplayTo(eventName, callback);
+            SubscribeToEvent(EventsRegistry.Intern(eventName), callback);
+        }
+
+        /// <inheritdoc/>
+        public void SubscribeToEvent(EventId eventId, Action<string, object, object> callback)
+        {
+            if (!eventId.IsValid || callback == null) return;
+            RegisterEvent(eventId);
+            events[eventId] += callback;
+            ReplayTo(eventId, callback);
         }
 
         /// <summary>
@@ -71,17 +85,18 @@ namespace CrawfisSoftware.Events
         /// inside a handler — while a drain is already in progress — enqueues and runs in order rather
         /// than nesting.</para>
         /// </remarks>
-        private void ReplayTo(string eventName, Action<string, object, object> callback)
+        private void ReplayTo(EventId eventId, Action<string, object, object> callback)
         {
+            string eventName = eventId.Name;
             switch (EventsRegistry.GetPolicy(eventName))
             {
                 case EventDelivery.Sticky:
-                    if (_stickyValues.TryGetValue(eventName, out RetainedValue retained))
+                    if (_stickyValues.TryGetValue(eventId, out RetainedValue retained))
                         _callbackQueue.Enqueue((eventName, callback, retained.Sender, retained.Data));
                     break;
 
                 case EventDelivery.Replay:
-                    if (_journals.TryGetValue(eventName, out List<RetainedValue> journal))
+                    if (_journals.TryGetValue(eventId, out List<RetainedValue> journal))
                         for (int i = 0; i < journal.Count; i++)
                             _callbackQueue.Enqueue((eventName, callback, journal[i].Sender, journal[i].Data));
                     break;
@@ -95,19 +110,19 @@ namespace CrawfisSoftware.Events
         /// <summary>
         /// Records a published value according to the event's delivery policy.
         /// </summary>
-        private void Retain(string eventName, object sender, object data)
+        private void Retain(EventId eventId, string eventName, object sender, object data)
         {
             switch (EventsRegistry.GetPolicy(eventName))
             {
                 case EventDelivery.Sticky:
-                    _stickyValues[eventName] = new RetainedValue(sender, data);
+                    _stickyValues[eventId] = new RetainedValue(sender, data);
                     break;
 
                 case EventDelivery.Replay:
-                    if (!_journals.TryGetValue(eventName, out List<RetainedValue> journal))
+                    if (!_journals.TryGetValue(eventId, out List<RetainedValue> journal))
                     {
                         journal = new List<RetainedValue>();
-                        _journals[eventName] = journal;
+                        _journals[eventId] = journal;
                     }
                     journal.Add(new RetainedValue(sender, data));
                     // Reported, never truncated: a silent cap would read as "everything was replayed".
@@ -127,15 +142,21 @@ namespace CrawfisSoftware.Events
         /// </summary>
         public bool TryGetLast(string eventName, out object sender, out object data)
         {
-            if (!string.IsNullOrEmpty(eventName))
+            return TryGetLast(EventsRegistry.Intern(eventName), out sender, out data);
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetLast(EventId eventId, out object sender, out object data)
+        {
+            if (eventId.IsValid)
             {
-                if (_stickyValues.TryGetValue(eventName, out RetainedValue retained))
+                if (_stickyValues.TryGetValue(eventId, out RetainedValue retained))
                 {
                     sender = retained.Sender;
                     data = retained.Data;
                     return true;
                 }
-                if (_journals.TryGetValue(eventName, out List<RetainedValue> journal) && journal.Count > 0)
+                if (_journals.TryGetValue(eventId, out List<RetainedValue> journal) && journal.Count > 0)
                 {
                     sender = journal[journal.Count - 1].Sender;
                     data = journal[journal.Count - 1].Data;
@@ -149,9 +170,15 @@ namespace CrawfisSoftware.Events
 
         public void UnsubscribeToEvent(string eventName, Action<string, object, object> callback)
         {
-            if (string.IsNullOrEmpty(eventName) || callback == null) return;
-            if (events.ContainsKey(eventName))
-                events[eventName] -= callback;
+            UnsubscribeToEvent(EventsRegistry.Intern(eventName), callback);
+        }
+
+        /// <inheritdoc/>
+        public void UnsubscribeToEvent(EventId eventId, Action<string, object, object> callback)
+        {
+            if (!eventId.IsValid || callback == null) return;
+            if (events.ContainsKey(eventId))
+                events[eventId] -= callback;
         }
 
         /// <summary>
@@ -159,7 +186,8 @@ namespace CrawfisSoftware.Events
         /// </summary>
         internal bool IsEventRegistered(string eventName)
         {
-            return !string.IsNullOrEmpty(eventName) && events.ContainsKey(eventName);
+            EventId eventId = EventsRegistry.Intern(eventName);
+            return eventId.IsValid && events.ContainsKey(eventId);
         }
 
         public void SubscribeToAllEvents(Action<string, object, object> callback)
@@ -174,7 +202,13 @@ namespace CrawfisSoftware.Events
 
         public void PublishEvent(string eventName, object sender, object data)
         {
-            PublishEvent(eventName, sender, data, retain: true);
+            PublishEvent(EventsRegistry.Intern(eventName), sender, data, retain: true);
+        }
+
+        /// <inheritdoc/>
+        public void PublishEvent(EventId eventId, object sender, object data)
+        {
+            PublishEvent(eventId, sender, data, retain: true);
         }
 
         /// <summary>
@@ -184,13 +218,14 @@ namespace CrawfisSoftware.Events
         /// frames still hear it, but retains only on the frame that was top at publish time. Retaining
         /// on every frame would mean <c>Pop()</c> discarded nothing, since the value would also be
         /// sitting in the frames underneath.</remarks>
-        internal void PublishEvent(string eventName, object sender, object data, bool retain)
+        internal void PublishEvent(EventId eventId, object sender, object data, bool retain)
         {
-            if (string.IsNullOrEmpty(eventName)) return;
+            if (!eventId.IsValid) return;
 
-            if (retain) Retain(eventName, sender, data);
+            string eventName = eventId.Name;
+            if (retain) Retain(eventId, eventName, sender, data);
 
-            if (events.TryGetValue(eventName, out Action<string, object, object> eventDelegate))
+            if (events.TryGetValue(eventId, out Action<string, object, object> eventDelegate))
             {
                 var callbacks = eventDelegate.GetInvocationList();
 
@@ -243,18 +278,18 @@ namespace CrawfisSoftware.Events
 
         public IEnumerable<string> GetRegisteredEvents()
         {
-            return events.Keys;
+            foreach (EventId eventId in events.Keys) yield return eventId.Name;
         }
 
         public IEnumerable<(string eventName, string typeName)> GetSubscribers()
         {
-            foreach (var eventName in events.Keys)
+            foreach (var eventId in events.Keys)
             {
-                if (events.TryGetValue(eventName, out var eventDelegate) && eventDelegate != null)
+                if (events.TryGetValue(eventId, out var eventDelegate) && eventDelegate != null)
                 {
                     foreach (var handler in eventDelegate.GetInvocationList().Skip(1))
                     {
-                        yield return (eventName, handler.Method.DeclaringType.ToString());
+                        yield return (eventId.Name, handler.Method.DeclaringType.ToString());
                     }
                 }
             }

--- a/Runtime/EventsRegistry.cs
+++ b/Runtime/EventsRegistry.cs
@@ -34,6 +34,10 @@ namespace CrawfisSoftware.Events
         private static readonly Dictionary<string, int> _handlesByName = new Dictionary<string, int>(StringComparer.Ordinal);
         private static readonly List<string> _namesByHandle = new List<string>();
 
+        // Declared payload type per event. Keyed on the id rather than the name because this is read on
+        // the publish path under StrictMode, and the id is already resolved by then.
+        private static readonly Dictionary<EventId, Type> _payloadTypes = new Dictionary<EventId, Type>();
+
         /// <summary>
         /// Resolves an event name to its <see cref="EventId"/>, interning it on first use.
         /// </summary>
@@ -109,6 +113,70 @@ namespace CrawfisSoftware.Events
             if (!string.IsNullOrEmpty(eventName) && _policies.TryGetValue(eventName, out EventDelivery policy))
                 return policy;
             return EventDelivery.Transient;
+        }
+
+        /// <summary>
+        /// Declares the payload type an event carries.
+        /// </summary>
+        /// <remarks>
+        /// <para>First declaration wins; a second, differing one is reported and ignored. That report is
+        /// the point of this table — two call sites disagreeing about what an event carries is the one
+        /// failure a typed identity cannot turn into a compile error, so it is turned into a loud error
+        /// at the moment the second one is minted instead.</para>
+        /// <para>Declaring <c>typeof(object)</c> means "anything goes" and disables the publish-time
+        /// check for that event, which is what an event with a genuinely untyped payload wants.</para>
+        /// </remarks>
+        internal static void DeclarePayload(EventId eventId, Type payloadType)
+        {
+            if (!eventId.IsValid || payloadType == null) return;
+
+            if (!_payloadTypes.TryGetValue(eventId, out Type existing))
+            {
+                _payloadTypes[eventId] = payloadType;
+                return;
+            }
+
+            if (existing != payloadType)
+            {
+                Debug.LogError(
+                    $"EventsRegistry: '{eventId.Name}' is already declared to carry {existing.FullName} and " +
+                    $"cannot be redeclared as {payloadType.FullName}. The first declaration is kept, so the " +
+                    "second call site will see payloads it cannot use.");
+            }
+        }
+
+        /// <summary>
+        /// Gets the declared payload type for an event, or <see langword="null"/> when nothing declared one.
+        /// </summary>
+        /// <remarks>Null means unchecked, not "carries nothing" — an event with no
+        /// <see cref="EventPayloadAttribute"/> and no typed identity behaves exactly as it did before
+        /// payloads could be declared.</remarks>
+        public static Type GetPayloadType(EventId eventId)
+        {
+            return _payloadTypes.TryGetValue(eventId, out Type payloadType) ? payloadType : null;
+        }
+
+        /// <summary>
+        /// Tests a payload against an event's declaration, describing the mismatch when there is one.
+        /// </summary>
+        /// <returns><see langword="true"/> when the payload is acceptable, or nothing was declared.</returns>
+        internal static bool IsPayloadAssignable(EventId eventId, object data, out Type declared)
+        {
+            declared = GetPayloadType(eventId);
+            if (declared == null || declared == typeof(object)) return true;
+
+            return data == null ? AcceptsNull(declared) : declared.IsInstanceOfType(data);
+        }
+
+        /// <summary>
+        /// True when <paramref name="payloadType"/> can hold a null payload.
+        /// </summary>
+        /// <remarks>The single definition of that rule. The publish-time check and the wrapper around a
+        /// typed handler both call it, so they cannot disagree about whether a null payload is legal —
+        /// if they did, one would report an event the other delivered as <c>default(TData)</c>.</remarks>
+        internal static bool AcceptsNull(Type payloadType)
+        {
+            return !payloadType.IsValueType || Nullable.GetUnderlyingType(payloadType) != null;
         }
 
         /// <summary>
@@ -189,6 +257,8 @@ namespace CrawfisSoftware.Events
             _resetHandlers.Clear();
             _claimedPrefixes.Clear();
             _policies.Clear();
+            _payloadTypes.Clear();
+            TypedSubscriptions.Clear();
             // The intern table is deliberately NOT cleared. Handles are values that callers may still
             // hold; recycling them would silently repoint an EventId at a different event. It is bounded
             // by the number of distinct event names in the project, so letting it persist costs nothing.

--- a/Runtime/EventsRegistry.cs
+++ b/Runtime/EventsRegistry.cs
@@ -23,6 +23,65 @@ namespace CrawfisSoftware.Events
         // Reset callbacks published by each EventsFor<T> that has been initialized.
         private static readonly List<Action> _resetHandlers = new List<Action>();
 
+        // Delivery policy per event name. Deliberately stack-global: RegisterEvent reaches only the top
+        // publisher frame, but PublishEvent visits every frame, so a per-frame policy would mean a
+        // pushed frame knew nothing about how to treat the events published into it. The retained
+        // values themselves stay per-frame, so Pop() still discards them.
+        private static readonly Dictionary<string, EventDelivery> _policies = new Dictionary<string, EventDelivery>();
+
+        /// <summary>
+        /// Number of retained entries after which a <see cref="EventDelivery.Replay"/> journal is
+        /// reported as growing without bound. Reported, never truncated — a silent cap would read as
+        /// "everything was replayed" when it was not.
+        /// </summary>
+        public const int JournalWarningThreshold = 1000;
+
+        /// <summary>
+        /// Declares the delivery policy for an event name.
+        /// </summary>
+        /// <remarks>
+        /// <para>First declaration wins; a second, differing one is reported and ignored.</para>
+        /// <para>Only an outright declaration — an <see cref="EventDeliveryAttribute"/> or the
+        /// <c>RegisterEvent(name, delivery)</c> overload — records anything here. Registering a name
+        /// without a policy, as <c>SubscribeToEvent</c> does on the fly, records nothing and leaves
+        /// <see cref="GetPolicy"/> falling through to its <see cref="EventDelivery.Transient"/>
+        /// default. That is what stops an early subscriber from pinning an event to Transient and
+        /// silently turning a later <c>[EventDelivery(Sticky)]</c> into a no-op.</para>
+        /// <para>Note this makes a declaration ordering-sensitive against publishes, not against
+        /// subscribes: a policy declared <em>after</em> an event has already been published does not
+        /// retroactively retain the value that was published under the old policy.</para>
+        /// </remarks>
+        /// <param name="eventName">The projected event name.</param>
+        /// <param name="delivery">The policy to apply.</param>
+        internal static void DeclarePolicy(string eventName, EventDelivery delivery)
+        {
+            if (string.IsNullOrEmpty(eventName)) return;
+
+            if (!_policies.TryGetValue(eventName, out EventDelivery existing))
+            {
+                _policies[eventName] = delivery;
+                return;
+            }
+
+            if (existing != delivery)
+            {
+                Debug.LogError(
+                    $"EventsRegistry: '{eventName}' is already declared as {existing} and cannot be " +
+                    $"redeclared as {delivery}. The first declaration is kept.");
+            }
+        }
+
+        /// <summary>
+        /// Gets the delivery policy for an event name, defaulting to
+        /// <see cref="EventDelivery.Transient"/>.
+        /// </summary>
+        public static EventDelivery GetPolicy(string eventName)
+        {
+            if (!string.IsNullOrEmpty(eventName) && _policies.TryGetValue(eventName, out EventDelivery policy))
+                return policy;
+            return EventDelivery.Transient;
+        }
+
         /// <summary>
         /// Records that <paramref name="enumType"/> projects onto <paramref name="prefix"/>, and reports
         /// a second enum type claiming the same one.
@@ -80,6 +139,7 @@ namespace CrawfisSoftware.Events
             }
             _resetHandlers.Clear();
             _claimedPrefixes.Clear();
+            _policies.Clear();
         }
 
         /// <summary>

--- a/Runtime/EventsRegistry.cs
+++ b/Runtime/EventsRegistry.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using UnityEngine;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// Non-generic home for state that must be shared across every <see cref="EventsFor{T}"/>, and the
+    /// entry points that run before any scene loads.
+    /// </summary>
+    /// <remarks>
+    /// This type is deliberately non-generic. A static field declared inside a generic type exists
+    /// once per constructed type — <c>Foo&lt;A&gt;</c> and <c>Foo&lt;B&gt;</c> get separate copies — so
+    /// anything that must compare one enum family against another cannot live there.
+    /// </remarks>
+    public static class EventsRegistry
+    {
+        // Which enum type has claimed a given "TypeName/" prefix, across all enum families.
+        private static readonly Dictionary<string, Type> _claimedPrefixes = new Dictionary<string, Type>();
+
+        // Reset callbacks published by each EventsFor<T> that has been initialized.
+        private static readonly List<Action> _resetHandlers = new List<Action>();
+
+        /// <summary>
+        /// Records that <paramref name="enumType"/> projects onto <paramref name="prefix"/>, and reports
+        /// a second enum type claiming the same one.
+        /// </summary>
+        /// <remarks>Event names are built from <see cref="Type.Name"/> rather than
+        /// <see cref="Type.FullName"/>, so two same-named enums in different namespaces would otherwise
+        /// silently share every event. Re-claiming by the same type is not a collision, which keeps this
+        /// idempotent when statics survive a domain reload.</remarks>
+        internal static void ClaimPrefix(string prefix, Type enumType)
+        {
+            if (string.IsNullOrEmpty(prefix) || enumType == null) return;
+            if (_claimedPrefixes.TryGetValue(prefix, out Type existing))
+            {
+                if (existing != enumType)
+                {
+                    Debug.LogError(
+                        $"EventsRegistry: '{enumType.FullName}' and '{existing.FullName}' both project onto the " +
+                        $"event name prefix '{prefix}/'. Their events will collide. Rename one of the enum types.");
+                }
+                return;
+            }
+            _claimedPrefixes[prefix] = enumType;
+        }
+
+        /// <summary>
+        /// Registers a callback that drops a generic facade's cached state, so it is rebuilt on next use.
+        /// </summary>
+        internal static void AddResetHandler(Action resetHandler)
+        {
+            if (resetHandler != null) _resetHandlers.Add(resetHandler);
+        }
+
+        /// <summary>
+        /// Clears static state carried over from a previous play session.
+        /// </summary>
+        /// <remarks>
+        /// <para>Runs at <see cref="RuntimeInitializeLoadType.SubsystemRegistration"/>, the earliest
+        /// runtime hook, so it completes before the <see cref="RuntimeInitializeLoadType.BeforeSceneLoad"/>
+        /// sweep below.</para>
+        /// <para>With domain reload enabled this is a no-op on already-empty state. It matters when
+        /// <em>Enter Play Mode Options</em> has domain reload disabled, where statics survive between
+        /// play sessions. Resetting explicitly rather than relying on that project setting keeps this
+        /// correct either way.</para>
+        /// <para>This deliberately does not clear <see cref="EventsPublisher"/> itself. Dropping live
+        /// subscriptions is a behavioral choice the project already exposes through the editor's
+        /// "Clear Events on Exiting Play Mode" toggle, and is not silently taken here.</para>
+        /// </remarks>
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void ResetStaticState()
+        {
+            for (int i = 0; i < _resetHandlers.Count; i++)
+            {
+                try { _resetHandlers[i](); }
+                catch (Exception e) { Debug.LogError($"EventsRegistry: reset handler failed: {e}"); }
+            }
+            _resetHandlers.Clear();
+            _claimedPrefixes.Clear();
+        }
+
+        /// <summary>
+        /// Registers every enum marked with <see cref="EventEnumAttribute"/> before the first scene loads.
+        /// </summary>
+        /// <remarks>See <see cref="EventEnumAttribute"/> for why this exists when
+        /// <see cref="EventsFor{T}"/> already registers lazily on first use.</remarks>
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void RegisterAnnotatedEventEnums()
+        {
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly.IsDynamic) continue;
+
+                Type[] types;
+                // A single unloadable dependency must not stop the sweep; take whatever loaded.
+                try { types = assembly.GetTypes(); }
+                catch (ReflectionTypeLoadException e) { types = e.Types; }
+                catch (Exception) { continue; }
+
+                foreach (Type type in types)
+                {
+                    if (type == null || !type.IsEnum) continue;
+                    if (!type.IsDefined(typeof(EventEnumAttribute), false)) continue;
+                    try
+                    {
+                        // EnsureRegistered is a non-generic method on a generic type, so the type is
+                        // closed first; MakeGenericMethod would be wrong here.
+                        Type facade = typeof(EventsFor<>).MakeGenericType(type);
+                        facade.GetMethod(EnsureRegisteredMethodName, BindingFlags.Public | BindingFlags.Static)
+                              .Invoke(null, null);
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogError($"EventsRegistry: could not register event enum '{type.FullName}': {e}");
+                    }
+                }
+            }
+        }
+
+        internal const string EnsureRegisteredMethodName = "EnsureRegistered";
+    }
+}

--- a/Runtime/EventsRegistry.cs
+++ b/Runtime/EventsRegistry.cs
@@ -29,6 +29,35 @@ namespace CrawfisSoftware.Events
         // values themselves stay per-frame, so Pop() still discards them.
         private static readonly Dictionary<string, EventDelivery> _policies = new Dictionary<string, EventDelivery>();
 
+        // The intern table: event name <-> EventId handle. Handles are one-based so that
+        // default(EventId) is 0 and therefore invalid.
+        private static readonly Dictionary<string, int> _handlesByName = new Dictionary<string, int>(StringComparer.Ordinal);
+        private static readonly List<string> _namesByHandle = new List<string>();
+
+        /// <summary>
+        /// Resolves an event name to its <see cref="EventId"/>, interning it on first use.
+        /// </summary>
+        /// <remarks>Costs one dictionary lookup. Publishing or subscribing through the returned id
+        /// costs none, which is the point: <see cref="EventsFor{T}"/> resolves each member of an enum
+        /// family once and never hashes a name again.</remarks>
+        public static EventId Intern(string eventName)
+        {
+            if (string.IsNullOrEmpty(eventName)) return default;
+            if (_handlesByName.TryGetValue(eventName, out int handle)) return new EventId(handle);
+
+            _namesByHandle.Add(eventName);
+            handle = _namesByHandle.Count;              // one-based
+            _handlesByName[eventName] = handle;
+            return new EventId(handle);
+        }
+
+        /// <summary>Gets the name an <see cref="EventId"/> was interned from.</summary>
+        internal static string GetInternedName(EventId eventId)
+        {
+            int handle = eventId.Handle;
+            return handle == 0 ? null : _namesByHandle[handle - 1];
+        }
+
         /// <summary>
         /// Number of retained entries after which a <see cref="EventDelivery.Replay"/> journal is
         /// reported as growing without bound. Reported, never truncated — a silent cap would read as
@@ -160,6 +189,10 @@ namespace CrawfisSoftware.Events
             _resetHandlers.Clear();
             _claimedPrefixes.Clear();
             _policies.Clear();
+            // The intern table is deliberately NOT cleared. Handles are values that callers may still
+            // hold; recycling them would silently repoint an EventId at a different event. It is bounded
+            // by the number of distinct event names in the project, so letting it persist costs nothing.
+
         }
 
         /// <summary>

--- a/Runtime/EventsRegistry.cs
+++ b/Runtime/EventsRegistry.cs
@@ -130,7 +130,7 @@ namespace CrawfisSoftware.Events
         /// "Clear Events on Exiting Play Mode" toggle, and is not silently taken here.</para>
         /// </remarks>
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-        private static void ResetStaticState()
+        internal static void ResetStaticState()
         {
             for (int i = 0; i < _resetHandlers.Count; i++)
             {
@@ -148,7 +148,7 @@ namespace CrawfisSoftware.Events
         /// <remarks>See <see cref="EventEnumAttribute"/> for why this exists when
         /// <see cref="EventsFor{T}"/> already registers lazily on first use.</remarks>
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-        private static void RegisterAnnotatedEventEnums()
+        internal static void RegisterAnnotatedEventEnums()
         {
             foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
             {

--- a/Runtime/EventsRegistry.cs
+++ b/Runtime/EventsRegistry.cs
@@ -83,6 +83,26 @@ namespace CrawfisSoftware.Events
         }
 
         /// <summary>
+        /// Gets the event-name prefix an enum type projects onto.
+        /// </summary>
+        /// <remarks>
+        /// <para>Defaults to <see cref="Type.Name"/>, so <c>GameFlowEvents.GameStarting</c> becomes
+        /// <c>"GameFlowEvents/GameStarting"</c>. <see cref="EventEnumAttribute.Prefix"/> overrides it,
+        /// which is how two enums with the same simple name in different namespaces are told apart
+        /// without renaming either type.</para>
+        /// <para>This is the single definition of the projection. The runtime facade and the editor's
+        /// Inspector dropdown both call it, so they cannot drift — if they did, the Inspector would
+        /// write a name the publisher is not keyed on.</para>
+        /// </remarks>
+        public static string GetPrefix(Type enumType)
+        {
+            if (enumType == null) return string.Empty;
+            var attribute = (EventEnumAttribute)Attribute.GetCustomAttribute(enumType, typeof(EventEnumAttribute));
+            string prefix = attribute == null ? null : attribute.Prefix;
+            return string.IsNullOrEmpty(prefix) ? enumType.Name : prefix;
+        }
+
+        /// <summary>
         /// Records that <paramref name="enumType"/> projects onto <paramref name="prefix"/>, and reports
         /// a second enum type claiming the same one.
         /// </summary>

--- a/Runtime/EventsRegistry.cs
+++ b/Runtime/EventsRegistry.cs
@@ -259,6 +259,9 @@ namespace CrawfisSoftware.Events
             _policies.Clear();
             _payloadTypes.Clear();
             TypedSubscriptions.Clear();
+            // Cleared at the start of a play session, not the end, so what the audit reads afterwards is
+            // one boot sequence rather than an editor session's accumulated noise.
+            EventsDiagnostics.Reset();
             // The intern table is deliberately NOT cleared. Handles are values that callers may still
             // hold; recycling them would silently repoint an EventId at a different event. It is bounded
             // by the number of distinct event names in the project, so letting it persist costs nothing.

--- a/Runtime/EventsRegistry.cs.meta
+++ b/Runtime/EventsRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 910691cc744e4efa96e51a583bb4d93d

--- a/Runtime/IEventsPublisher.cs
+++ b/Runtime/IEventsPublisher.cs
@@ -37,6 +37,31 @@ namespace CrawfisSoftware.Events
         void RegisterEvent(T eventName);
 
         /// <summary>
+        /// Registers an event and declares its <see cref="EventDelivery"/> policy.
+        /// </summary>
+        /// <remarks>The escape hatch for names no enum can annotate — runtime-computed names and
+        /// Inspector-authored strings. For an enum family, prefer <see cref="EventDeliveryAttribute"/>
+        /// on the member. Declare from a static initializer rather than <c>Awake</c>: the policy must
+        /// be in place before the event is first published, or that first publish is not retained.
+        /// First declaration wins; a differing second one is reported and ignored.</remarks>
+        void RegisterEvent(T eventName, EventDelivery delivery);
+
+        /// <summary>
+        /// Retrieves the most recently retained value for an event, without subscribing to it.
+        /// </summary>
+        /// <remarks>Only events declared <see cref="EventDelivery.Sticky"/> or
+        /// <see cref="EventDelivery.Replay"/> retain anything; a
+        /// <see cref="EventDelivery.Transient"/> event always reports <see langword="false"/>. Use this
+        /// for code that wants the current value but has no reason to subscribe — a one-shot read, a
+        /// non-<c>MonoBehaviour</c>, an editor tool. Subscribers do not need it: a subscription to a
+        /// retaining event is delivered the retained value immediately.</remarks>
+        /// <param name="eventName">The event to query.</param>
+        /// <param name="sender">The sender recorded with the retained value, or <see langword="null"/>.</param>
+        /// <param name="data">The data recorded with the retained value, or <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> if a value was retained.</returns>
+        bool TryGetLast(T eventName, out object sender, out object data);
+
+        /// <summary>
         /// Subscribes to all events and invokes the specified callback when an event occurs.
         /// </summary>
         /// <remarks>The callback is invoked for every event without filtering. Ensure the callback

--- a/Runtime/TypedEvents.cs
+++ b/Runtime/TypedEvents.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// The publish and subscribe operations for a typed identity.
+    /// </summary>
+    /// <remarks>
+    /// <para>Extension methods rather than members of <see cref="EventId{TData}"/>, so that the struct
+    /// stays a pure identity and does not carry a dependency on a particular publisher.</para>
+    /// <para>Each operation has an overload taking an explicit <see cref="IEventsPublisher{T}"/>, for a
+    /// pushed frame or an injected publisher; the short form uses
+    /// <see cref="EventsPublisher.Instance"/>.</para>
+    /// </remarks>
+    public static class EventIdExtensions
+    {
+        /// <summary>Publishes a typed payload. Passing the wrong type is a compile error.</summary>
+        public static void Publish<TData>(this EventId<TData> eventId, object sender, TData data)
+        {
+            eventId.Publish(EventsPublisher.Instance, sender, data);
+        }
+
+        /// <inheritdoc cref="Publish{TData}(EventId{TData}, object, TData)"/>
+        public static void Publish<TData>(this EventId<TData> eventId, IEventsPublisher<string> publisher, object sender, TData data)
+        {
+            if (publisher == null || !eventId.IsValid) return;
+            if (publisher is IEventIdPublisher idPublisher) idPublisher.PublishEvent(eventId.Untyped, sender, data);
+            else publisher.PublishEvent(eventId.Name, sender, data);
+        }
+
+        /// <summary>
+        /// Subscribes a handler whose <c>data</c> parameter is <typeparamref name="TData"/>, with no cast.
+        /// </summary>
+        /// <remarks>The handler is wrapped in an erased one for the publisher, and the wrapper is
+        /// remembered so that <see cref="Unsubscribe{TData}(EventId{TData}, Action{string, object, TData})"/>
+        /// removes the same delegate rather than a fresh one that would match nothing.</remarks>
+        public static void Subscribe<TData>(this EventId<TData> eventId, Action<string, object, TData> callback)
+        {
+            eventId.Subscribe(EventsPublisher.Instance, callback);
+        }
+
+        /// <inheritdoc cref="Subscribe{TData}(EventId{TData}, Action{string, object, TData})"/>
+        public static void Subscribe<TData>(this EventId<TData> eventId, IEventsPublisher<string> publisher, Action<string, object, TData> callback)
+        {
+            if (publisher == null || !eventId.IsValid || callback == null) return;
+
+            Action<string, object, object> wrapper = TypedSubscriptions.Acquire(eventId.Untyped, callback);
+            if (publisher is IEventIdPublisher idPublisher) idPublisher.SubscribeToEvent(eventId.Untyped, wrapper);
+            else publisher.SubscribeToEvent(eventId.Name, wrapper);
+        }
+
+        /// <summary>Unsubscribes a handler subscribed through the typed API.</summary>
+        public static void Unsubscribe<TData>(this EventId<TData> eventId, Action<string, object, TData> callback)
+        {
+            eventId.Unsubscribe(EventsPublisher.Instance, callback);
+        }
+
+        /// <inheritdoc cref="Unsubscribe{TData}(EventId{TData}, Action{string, object, TData})"/>
+        public static void Unsubscribe<TData>(this EventId<TData> eventId, IEventsPublisher<string> publisher, Action<string, object, TData> callback)
+        {
+            if (publisher == null || !eventId.IsValid || callback == null) return;
+
+            Action<string, object, object> wrapper = TypedSubscriptions.Release(eventId.Untyped, callback);
+            if (wrapper == null) return; // Never subscribed through the typed API; a no-op, as untyped is.
+
+            if (publisher is IEventIdPublisher idPublisher) idPublisher.UnsubscribeToEvent(eventId.Untyped, wrapper);
+            else publisher.UnsubscribeToEvent(eventId.Name, wrapper);
+        }
+
+        /// <summary>Registers a typed event, with a delivery policy, without subscribing to it.</summary>
+        /// <remarks>Needed only for an identity minted by <see cref="EventId{TData}.Of"/>; an identity
+        /// from <see cref="EventsFor{T}.Id{TData}"/> is registered along with the rest of its family.</remarks>
+        public static void Register<TData>(this EventId<TData> eventId, EventDelivery delivery = EventDelivery.Transient)
+        {
+            if (!eventId.IsValid) return;
+            EventsPublisher.Instance.RegisterEvent(eventId.Name, delivery);
+        }
+
+        /// <summary>
+        /// Reads the retained value for a typed event, without subscribing.
+        /// </summary>
+        /// <returns><see langword="false"/> when nothing is retained, and also when what is retained is
+        /// not a <typeparamref name="TData"/> — which an untyped publish can leave behind.</returns>
+        public static bool TryGetLast<TData>(this EventId<TData> eventId, out object sender, out TData data)
+        {
+            return eventId.TryGetLast(EventsPublisher.Instance, out sender, out data);
+        }
+
+        /// <inheritdoc cref="TryGetLast{TData}(EventId{TData}, out object, out TData)"/>
+        public static bool TryGetLast<TData>(this EventId<TData> eventId, IEventsPublisher<string> publisher, out object sender, out TData data)
+        {
+            data = default(TData);
+            sender = null;
+            if (publisher == null || !eventId.IsValid) return false;
+
+            object raw;
+            bool found = publisher is IEventIdPublisher idPublisher
+                ? idPublisher.TryGetLast(eventId.Untyped, out sender, out raw)
+                : publisher.TryGetLast(eventId.Name, out sender, out raw);
+            if (!found) return false;
+
+            if (raw is TData typed)
+            {
+                data = typed;
+                return true;
+            }
+            if (raw == null && TypedSubscriptions.AcceptsNull<TData>()) return true;
+
+            TypedSubscriptions.ReportMismatch(eventId.Name, typeof(TData), raw, "reading the retained value for");
+            sender = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Remembers the erased wrapper standing in for each typed handler, so that unsubscribing removes
+    /// the delegate that was actually subscribed.
+    /// </summary>
+    /// <remarks>
+    /// <para>Without this, wrapping a typed handler at subscribe time would be a silent leak: the
+    /// wrapper is a new delegate each time, so a later <c>Unsubscribe</c> would build a second wrapper,
+    /// hand it to <c>-=</c>, match nothing, and leave the original subscribed forever.</para>
+    /// <para>Keyed on <c>(EventId, handler)</c> and reference-counted, so that subscribing the same
+    /// handler twice fires it twice and takes two unsubscribes to remove — the same semantics the
+    /// untyped <c>+=</c> and <c>-=</c> already have.</para>
+    /// </remarks>
+    internal static class TypedSubscriptions
+    {
+        private sealed class Entry
+        {
+            public Action<string, object, object> Wrapper;
+            public int Count;
+        }
+
+        private static readonly Dictionary<(EventId, Delegate), Entry> _wrappers
+            = new Dictionary<(EventId, Delegate), Entry>();
+
+        /// <summary>Gets the wrapper for a handler, creating it on the first subscribe.</summary>
+        internal static Action<string, object, object> Acquire<TData>(EventId eventId, Action<string, object, TData> callback)
+        {
+            var key = (eventId, (Delegate)callback);
+            if (!_wrappers.TryGetValue(key, out Entry entry))
+            {
+                entry = new Entry { Wrapper = MakeWrapper(eventId, callback), Count = 0 };
+                _wrappers[key] = entry;
+            }
+            entry.Count++;
+            return entry.Wrapper;
+        }
+
+        /// <summary>
+        /// Gets the wrapper to unsubscribe, or <see langword="null"/> when this handler is not subscribed.
+        /// </summary>
+        internal static Action<string, object, object> Release<TData>(EventId eventId, Action<string, object, TData> callback)
+        {
+            var key = (eventId, (Delegate)callback);
+            if (!_wrappers.TryGetValue(key, out Entry entry)) return null;
+
+            entry.Count--;
+            if (entry.Count <= 0) _wrappers.Remove(key);
+            return entry.Wrapper;
+        }
+
+        internal static void Clear()
+        {
+            _wrappers.Clear();
+        }
+
+        /// <summary>True when <typeparamref name="TData"/> can hold a null payload.</summary>
+        internal static bool AcceptsNull<TData>()
+        {
+            return EventsRegistry.AcceptsNull(typeof(TData));
+        }
+
+        /// <summary>
+        /// Builds the erased delegate the publisher holds, which narrows the payload back to
+        /// <typeparamref name="TData"/> before calling the typed handler.
+        /// </summary>
+        /// <remarks>A payload that does not fit is reported and the handler is skipped, rather than
+        /// throwing an <see cref="InvalidCastException"/> from inside it. Both end up in the console, but
+        /// a cast exception names neither the event nor the type that was expected, which is most of what
+        /// is needed to find the publisher at fault.</remarks>
+        private static Action<string, object, object> MakeWrapper<TData>(EventId eventId, Action<string, object, TData> callback)
+        {
+            return (eventName, sender, data) =>
+            {
+                if (data is TData typed)
+                {
+                    callback(eventName, sender, typed);
+                    return;
+                }
+                if (data == null && AcceptsNull<TData>())
+                {
+                    callback(eventName, sender, default(TData));
+                    return;
+                }
+                ReportMismatch(eventName, typeof(TData), data, "delivering to a handler of");
+            };
+        }
+
+        internal static void ReportMismatch(string eventName, Type expected, object data, string action)
+        {
+            string actual = data == null ? "null" : data.GetType().FullName;
+            UnityEngine.Debug.LogError(
+                $"EventsPublisher: {action} '{eventName}' expected a payload of {expected.FullName} but got {actual}. " +
+                "The handler was skipped. Something published this event with the wrong payload — check the " +
+                "untyped publishes of this name.");
+        }
+    }
+}

--- a/Runtime/TypedEvents.cs.meta
+++ b/Runtime/TypedEvents.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1976af83600444af85d887fc4aeb106a

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f5fc442a73e48d6bf4ce6aff7fa116e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor.meta
+++ b/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3178624084c64f4c8a64175487a0b583
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/CrawfisSoftware.EventsPublisher.Tests.asmdef
+++ b/Tests/Editor/CrawfisSoftware.EventsPublisher.Tests.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "CrawfisSoftware.EventsPublisher.Tests",
+    "rootNamespace": "CrawfisSoftware.Events.Tests",
+    "references": [
+        "CrawfisSoftware.EventsPublisher",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Tests/Editor/CrawfisSoftware.EventsPublisher.Tests.asmdef
+++ b/Tests/Editor/CrawfisSoftware.EventsPublisher.Tests.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "CrawfisSoftware.Events.Tests",
     "references": [
         "CrawfisSoftware.EventsPublisher",
+        "CrawfisSoftware.EventsPublisher.Editor",
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner"
     ],

--- a/Tests/Editor/CrawfisSoftware.EventsPublisher.Tests.asmdef.meta
+++ b/Tests/Editor/CrawfisSoftware.EventsPublisher.Tests.asmdef.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dc67e5839fee4ffbb4bb75acaf49173b

--- a/Tests/Editor/EventDeliveryTests.cs
+++ b/Tests/Editor/EventDeliveryTests.cs
@@ -1,0 +1,192 @@
+using System.Text.RegularExpressions;
+
+using NUnit.Framework;
+
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    /// <summary>Mirrors the shape of TempleRunEvents: an edge, a level, and an accumulation.</summary>
+    [EventEnum]
+    public enum DeliveryTestEvents
+    {
+        PlayerFailingAtTurn = 12,
+        [EventDelivery(EventDelivery.Sticky)] PlayerDied = 5,
+        [EventDelivery(EventDelivery.Replay)] SegmentCreated = 40,
+    }
+
+    /// <summary>
+    /// Retention and replay: the three delivery policies, declaration rules, and scoping.
+    /// </summary>
+    public class EventDeliveryTests : EventsTestBase
+    {
+        [Test]
+        public void Transient_RetainsNothing()
+        {
+            EventsFor<DeliveryTestEvents>.Publish(DeliveryTestEvents.PlayerFailingAtTurn, null, "turn1");
+
+            EventsFor<DeliveryTestEvents>.Subscribe(DeliveryTestEvents.PlayerFailingAtTurn, Recorder("late"));
+
+            // Replaying an edge would re-trigger whatever the transition drives.
+            Assert.AreEqual(0, Log.Count);
+            Assert.IsFalse(EventsFor<DeliveryTestEvents>.TryGetLast(DeliveryTestEvents.PlayerFailingAtTurn, out _, out _));
+        }
+
+        [Test]
+        public void Sticky_DeliversTheLastValueDuringSubscribe()
+        {
+            EventsFor<DeliveryTestEvents>.Publish(DeliveryTestEvents.PlayerDied, null, 100);
+            EventsFor<DeliveryTestEvents>.Publish(DeliveryTestEvents.PlayerDied, null, 250);
+
+            EventsFor<DeliveryTestEvents>.Subscribe(DeliveryTestEvents.PlayerDied, Recorder("late"));
+
+            // Immediate, not deferred: the subscriber knows the current state by the time Subscribe
+            // returns, so it does not spend the rest of the frame wrong about the world.
+            Assert.AreEqual("late:250", string.Join(",", Log), "only the most recent value, delivered inline");
+        }
+
+        [Test]
+        public void Sticky_CarriesThePayloadThatABoolMirrorCannot()
+        {
+            EventsFor<DeliveryTestEvents>.Publish(DeliveryTestEvents.PlayerDied, null, 250);
+
+            Assert.IsTrue(EventsFor<DeliveryTestEvents>.TryGetLast(DeliveryTestEvents.PlayerDied, out _, out object data));
+            Assert.AreEqual(250, data);
+        }
+
+        [Test]
+        public void Replay_DeliversTheWholeJournalInOrder()
+        {
+            EventsFor<DeliveryTestEvents>.Publish(DeliveryTestEvents.SegmentCreated, null, "s1");
+            EventsFor<DeliveryTestEvents>.Publish(DeliveryTestEvents.SegmentCreated, null, "s2");
+            EventsFor<DeliveryTestEvents>.Publish(DeliveryTestEvents.SegmentCreated, null, "s3");
+
+            EventsFor<DeliveryTestEvents>.Subscribe(DeliveryTestEvents.SegmentCreated, Recorder("late"));
+
+            Assert.AreEqual("late:s1,late:s2,late:s3", string.Join(",", Log));
+        }
+
+        [Test]
+        public void SubscribeFromInsideAHandler_EnqueuesTheReplayRatherThanNesting()
+        {
+            // The implementation risk called out when replay moved from end-of-frame to immediate.
+            Bus.RegisterEvent("Trigger");
+            Bus.RegisterEvent("StickyX", EventDelivery.Sticky);
+            Bus.PublishEvent("StickyX", null, "X");
+
+            Bus.SubscribeToEvent("Trigger", (e, s, d) =>
+            {
+                Log.Add("H1-start");
+                Bus.SubscribeToEvent("StickyX", Recorder("replayed"));
+                Log.Add("H1-end");
+            });
+            Bus.SubscribeToEvent("Trigger", (e, s, d) => Log.Add("H2"));
+
+            Bus.PublishEvent("Trigger", null, null);
+
+            Assert.AreEqual("H1-start,H1-end,H2,replayed:X", string.Join(",", Log),
+                "the replay must run after the in-flight drain, not inside H1");
+        }
+
+        [Test]
+        public void RedeclaringTheSamePolicy_IsNotAConflict()
+        {
+            Bus.RegisterEvent("Conflicted", EventDelivery.Sticky);
+            Bus.RegisterEvent("Conflicted", EventDelivery.Sticky);
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void ConflictingDeclaration_IsReportedAndTheFirstIsKept()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("already declared as Sticky.*redeclared as Replay"));
+
+            Bus.RegisterEvent("Conflicted", EventDelivery.Sticky);
+            Bus.RegisterEvent("Conflicted", EventDelivery.Replay);
+
+            Assert.AreEqual(EventDelivery.Sticky, EventsRegistry.GetPolicy("Conflicted"));
+        }
+
+        [Test]
+        public void SubscribingBeforeDeclaring_DoesNotPinTheEventToTransient()
+        {
+            // SubscribeToEvent registers the name on the fly. If that recorded a Transient default, this
+            // later declaration would be silently ignored and the event would never retain.
+            Bus.SubscribeToEvent("LateDeclared", (e, s, d) => { });
+            Bus.RegisterEvent("LateDeclared", EventDelivery.Sticky);
+
+            Assert.AreEqual(EventDelivery.Sticky, EventsRegistry.GetPolicy("LateDeclared"));
+
+            Bus.PublishEvent("LateDeclared", null, "v");
+            Bus.SubscribeToEvent("LateDeclared", Recorder("late"));
+
+            Assert.AreEqual("late:v", string.Join(",", Log));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void DeclaringAfterAPublish_DoesNotRetroactivelyRetain()
+        {
+            // Documents the ordering that remains: a policy is sensitive to publishes, not subscribes.
+            // The attribute sweep and lazy facade init exist so this cannot happen for enum families.
+            Bus.RegisterEvent("Late");
+            Bus.PublishEvent("Late", null, "missed");
+
+            Bus.RegisterEvent("Late", EventDelivery.Sticky);
+            Bus.SubscribeToEvent("Late", Recorder("late"));
+
+            Assert.AreEqual(0, Log.Count, "the value published under the old policy was never retained");
+        }
+
+        [Test]
+        public void Pop_DiscardsOnlyTheFrameThatRetained()
+        {
+            Bus.RegisterEvent("Scoped", EventDelivery.Sticky);
+            Bus.PublishEvent("Scoped", null, "outer");
+
+            Bus.Push();
+            Bus.PublishEvent("Scoped", null, "inner");
+            Bus.SubscribeToEvent("Scoped", Recorder("top"));
+            Assert.AreEqual("top:inner", string.Join(",", Log), "the top frame replays its own value");
+            Bus.Pop();
+
+            // Every frame is dispatched to, but only the frame that is top at publish time retains.
+            // Retaining on dispatch would leave a copy below, and Pop would discard nothing — which
+            // would make Push/Pop useless as a scope for Replay journals.
+            Assert.IsTrue(Bus.TryGetLast("Scoped", out _, out object data));
+            Assert.AreEqual("outer", data);
+        }
+
+        [Test]
+        public void Clear_DropsRetainedValues()
+        {
+            Bus.RegisterEvent("Scoped", EventDelivery.Sticky);
+            Bus.PublishEvent("Scoped", null, "v");
+
+            Bus.Clear();
+
+            Assert.IsFalse(Bus.TryGetLast("Scoped", out _, out _));
+        }
+
+        [Test]
+        public void LowerFrameSubscribers_StillHearEventsPublishedWhileAFrameIsPushed()
+        {
+            Bus.RegisterEvent("Heard");
+            Bus.SubscribeToEvent("Heard", Recorder("lower"));
+
+            Bus.Push();
+            try
+            {
+                Bus.PublishEvent("Heard", null, "v");
+            }
+            finally
+            {
+                Bus.Pop();
+            }
+
+            Assert.AreEqual("lower:v", string.Join(",", Log), "scoping retention must not change dispatch");
+        }
+    }
+}

--- a/Tests/Editor/EventDeliveryTests.cs.meta
+++ b/Tests/Editor/EventDeliveryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f90d64c9cdf7475eaa0e766b58efdb82

--- a/Tests/Editor/EventIdTests.cs
+++ b/Tests/Editor/EventIdTests.cs
@@ -1,0 +1,119 @@
+using NUnit.Framework;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    [EventEnum]
+    public enum IdTestEvents { Alpha, Beta }
+
+    /// <summary>
+    /// The interned identity: the string becomes a projection off it, and both the id-keyed and
+    /// name-keyed paths must reach the same event.
+    /// </summary>
+    public class EventIdTests : EventsTestBase
+    {
+        [Test]
+        public void SameName_InternsToTheSameId()
+        {
+            Assert.AreEqual(EventId.Of("A/One"), EventId.Of("A/One"));
+        }
+
+        [Test]
+        public void DifferentNames_InternToDifferentIds()
+        {
+            Assert.AreNotEqual(EventId.Of("A/One"), EventId.Of("A/Two"));
+        }
+
+        [Test]
+        public void NameIsAProjectionOffTheId()
+        {
+            Assert.AreEqual("A/One", EventId.Of("A/One").Name);
+        }
+
+        [Test]
+        public void DefaultId_IsInvalidRatherThanAliasingTheFirstEvent()
+        {
+            // Handles are one-based precisely so an unassigned field cannot silently mean "the first
+            // event that happened to be registered".
+            var unset = default(EventId);
+
+            Assert.IsFalse(unset.IsValid);
+            Assert.IsNull(unset.Name);
+            Assert.AreNotEqual(EventId.Of("A/One"), unset);
+        }
+
+        [Test]
+        public void NullAndEmptyNames_InternToTheInvalidId()
+        {
+            Assert.IsFalse(EventId.Of(null).IsValid);
+            Assert.IsFalse(EventId.Of(string.Empty).IsValid);
+        }
+
+        [Test]
+        public void PublishingThroughAnUnsetId_IsANoOp()
+        {
+            EventsPublisher.StrictMode = false;
+            var idBus = (IEventIdPublisher)Bus;
+
+            Assert.DoesNotThrow(() =>
+            {
+                idBus.SubscribeToEvent(default, Recorder("x"));
+                idBus.PublishEvent(default, null, null);
+                idBus.UnsubscribeToEvent(default, Recorder("x"));
+            });
+            Assert.IsFalse(idBus.TryGetLast(default, out _, out _));
+        }
+
+        [Test]
+        public void IdPathAndNamePath_ReachTheSameEvent()
+        {
+            // The whole refactor rests on this: the two entry points must key on the same thing, or a
+            // subscriber registered one way silently misses a publish made the other way.
+            var idBus = (IEventIdPublisher)Bus;
+            EventId id = EventId.Of("Shared/Event");
+
+            Bus.SubscribeToEvent("Shared/Event", Recorder("byName"));
+            idBus.SubscribeToEvent(id, Recorder("byId"));
+
+            idBus.PublishEvent(id, null, "viaId");
+            Bus.PublishEvent("Shared/Event", null, "viaName");
+
+            Assert.AreEqual("byName:viaId,byId:viaId,byName:viaName,byId:viaName", string.Join(",", Log));
+        }
+
+        [Test]
+        public void FacadeIdMatchesTheProjectedName()
+        {
+            Assert.AreEqual(
+                EventId.Of(EventsFor<IdTestEvents>.GetEventName(IdTestEvents.Alpha)),
+                EventsFor<IdTestEvents>.GetEventId(IdTestEvents.Alpha));
+        }
+
+        [Test]
+        public void IdsSurviveTheStaticReset()
+        {
+            // The intern table deliberately outlives ResetStaticState. Recycling handles would silently
+            // repoint an EventId a caller still holds at a different event.
+            EventId before = EventId.Of("Durable/Event");
+
+            EventsRegistry.ResetStaticState();
+
+            Assert.AreEqual(before, EventId.Of("Durable/Event"));
+            Assert.AreEqual("Durable/Event", before.Name);
+        }
+
+        [Test]
+        public void RetainedValuesAreReachableThroughEitherPath()
+        {
+            var idBus = (IEventIdPublisher)Bus;
+            EventId id = EventId.Of("Retained/Event");
+            Bus.RegisterEvent("Retained/Event", EventDelivery.Sticky);
+
+            idBus.PublishEvent(id, null, "value");
+
+            Assert.IsTrue(Bus.TryGetLast("Retained/Event", out _, out object byName));
+            Assert.IsTrue(idBus.TryGetLast(id, out _, out object byId));
+            Assert.AreEqual("value", byName);
+            Assert.AreEqual("value", byId);
+        }
+    }
+}

--- a/Tests/Editor/EventIdTests.cs.meta
+++ b/Tests/Editor/EventIdTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2a84bd22bfd74704aaa40272bf4ee305

--- a/Tests/Editor/EventNameCatalogTests.cs
+++ b/Tests/Editor/EventNameCatalogTests.cs
@@ -1,0 +1,79 @@
+using System;
+
+using CrawfisSoftware.Events.Editor;
+
+using NUnit.Framework;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    [EventEnum]
+    public enum CatalogTestEvents { Beta, Alpha }
+
+    /// <summary>
+    /// The Inspector dropdown and the runtime publisher must agree on the projected name, and an
+    /// unrecognised serialized value must survive being displayed.
+    /// </summary>
+    public class EventNameCatalogTests : EventsTestBase
+    {
+        [Test]
+        public void CatalogProjection_MatchesTheRuntimeProjection()
+        {
+            // The editor cannot call the generic runtime projection, so it reimplements it. If the two
+            // ever diverge, the Inspector writes a name the publisher is not keyed on and the event
+            // silently reaches nobody — which is the whole failure this control exists to prevent.
+            string[] names = EventNameCatalog.BuildNames(new[] { typeof(CatalogTestEvents) });
+
+            foreach (CatalogTestEvents value in Enum.GetValues(typeof(CatalogTestEvents)))
+            {
+                string runtimeName = EventsFor<CatalogTestEvents>.GetEventName(value);
+                Assert.IsTrue(Array.IndexOf(names, runtimeName) >= 0,
+                    "catalog is missing the runtime-projected name " + runtimeName);
+            }
+        }
+
+        [Test]
+        public void BuildNames_IsSortedAndDeduplicated()
+        {
+            string[] names = EventNameCatalog.BuildNames(new[] { typeof(CatalogTestEvents), typeof(CatalogTestEvents) });
+
+            Assert.AreEqual(2, names.Length, "the same enum listed twice must not duplicate entries");
+            Assert.AreEqual("CatalogTestEvents/Alpha", names[0]);
+            Assert.AreEqual("CatalogTestEvents/Beta", names[1]);
+        }
+
+        [Test]
+        public void BuildNames_IgnoresNullsAndNonEnums()
+        {
+            Assert.AreEqual(0, EventNameCatalog.BuildNames(null).Length);
+            Assert.AreEqual(0, EventNameCatalog.BuildNames(new Type[] { null, typeof(string) }).Length);
+        }
+
+        [Test]
+        public void Options_SelectNoneWhenUnset()
+        {
+            string[] options = EventNamePopup.BuildOptions(new[] { "A/One" }, string.Empty, out int selected);
+
+            Assert.AreEqual(0, selected);
+            Assert.AreEqual("<none>", options[0]);
+        }
+
+        [Test]
+        public void Options_SelectTheMatchingKnownName()
+        {
+            string[] options = EventNamePopup.BuildOptions(new[] { "A/One", "A/Two" }, "A/Two", out int selected);
+
+            Assert.AreEqual("A/Two", options[selected]);
+        }
+
+        [Test]
+        public void Options_SurfaceAnUnknownValueRatherThanClearingIt()
+        {
+            // A name whose enum is not marked [EventEnum], or that has since been renamed, must not be
+            // silently replaced by the first alphabetical event the moment the Inspector paints it.
+            string[] options = EventNamePopup.BuildOptions(new[] { "A/One" }, "Legacy/Baked", out int selected);
+
+            Assert.AreEqual("Missing/Legacy/Baked", options[selected]);
+            Assert.IsTrue(selected > 0, "the unknown value must be selected, not <none>");
+        }
+    }
+}

--- a/Tests/Editor/EventNameCatalogTests.cs.meta
+++ b/Tests/Editor/EventNameCatalogTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d658dfe9dad44690b7422ae6904ec29e

--- a/Tests/Editor/EventPayloadTests.cs
+++ b/Tests/Editor/EventPayloadTests.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Text.RegularExpressions;
+
+using NUnit.Framework;
+
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    /// <summary>A reference-typed payload, so null is a legal value for it.</summary>
+    public class PayloadData
+    {
+        public int Value;
+        public override string ToString() => "P" + Value;
+    }
+
+    public enum PayloadTestEvents
+    {
+        [EventPayload(typeof(PayloadData))] Detailed,
+
+        // A value-typed payload: null is not a legal value here, which is a case worth its own tests.
+        [EventPayload(typeof(int))] Counted,
+
+        // Deliberately unannotated: the payload stays unchecked, as it was before Stage 3.
+        Loose,
+
+        [EventPayload(typeof(int))]
+        [EventDelivery(EventDelivery.Sticky)]
+        Score,
+
+        [EventPayload(typeof(PayloadData))]
+        [EventDelivery(EventDelivery.Sticky)]
+        Level,
+    }
+
+    /// <summary>
+    /// Typed payloads: what the compiler covers, what the runtime has to check instead, and that
+    /// erasure still holds for the observer channel.
+    /// </summary>
+    public class EventPayloadTests : EventsTestBase
+    {
+        private static EventId<PayloadData> Detailed => EventsFor<PayloadTestEvents>.Id<PayloadData>(PayloadTestEvents.Detailed);
+        private static EventId<int> Counted => EventsFor<PayloadTestEvents>.Id<int>(PayloadTestEvents.Counted);
+        private static EventId<PayloadData> Level => EventsFor<PayloadTestEvents>.Id<PayloadData>(PayloadTestEvents.Level);
+        private static EventId<int> Score => EventsFor<PayloadTestEvents>.Id<int>(PayloadTestEvents.Score);
+
+        // ---- delivery ----
+
+        [Test]
+        public void TypedHandler_ReceivesThePayloadWithNoCast()
+        {
+            Detailed.Subscribe(OnDetailed);
+            Detailed.Publish(null, new PayloadData { Value = 7 });
+
+            Assert.AreEqual("detailed:7", string.Join(",", Log));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void TypedPublish_ReachesAnUntypedSubscriberOfTheSameEvent()
+        {
+            // The typed API must be a view onto the same event, not a parallel channel. If it were
+            // separate, every existing subscriber in a migrating project would silently stop hearing it.
+            Bus.SubscribeToEvent(EventsFor<PayloadTestEvents>.GetEventName(PayloadTestEvents.Detailed), Recorder("erased"));
+            Detailed.Publish(null, new PayloadData { Value = 3 });
+
+            Assert.AreEqual("erased:P3", string.Join(",", Log));
+        }
+
+        [Test]
+        public void AllEventsSubscriber_StillSeesATypedPublish()
+        {
+            // The global logger and EventHistory subscribe this way. Stage 3 must not cost them anything.
+            Bus.SubscribeToAllEvents(Recorder("all"));
+            Detailed.Publish(null, new PayloadData { Value = 1 });
+
+            Assert.AreEqual("all:P1", string.Join(",", Log));
+        }
+
+        [Test]
+        public void UntypedPublish_IsDeliveredToATypedHandler()
+        {
+            // The other direction: a raw-string publisher that has not migrated must still reach a
+            // handler that has.
+            Detailed.Subscribe(OnDetailed);
+            Bus.PublishEvent(Detailed.Name, null, new PayloadData { Value = 9 });
+
+            Assert.AreEqual("detailed:9", string.Join(",", Log));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        // ---- unsubscribe: the wrapper table ----
+
+        [Test]
+        public void Unsubscribe_RemovesTheHandlerRatherThanLeakingIt()
+        {
+            // A typed handler is wrapped in an erased one before it reaches the publisher. If the
+            // wrapper were rebuilt per call, this unsubscribe would hand the publisher a delegate that
+            // matches nothing and the handler would stay subscribed forever.
+            Detailed.Subscribe(OnDetailed);
+            Detailed.Unsubscribe(OnDetailed);
+            Detailed.Publish(null, new PayloadData { Value = 4 });
+
+            Assert.AreEqual("", string.Join(",", Log));
+        }
+
+        [Test]
+        public void SubscribingTwice_FiresTwiceAndNeedsTwoUnsubscribes()
+        {
+            // Matching what the untyped += and -= already do, so the wrapper cannot quietly change the
+            // semantics of a double subscription.
+            Detailed.Subscribe(OnDetailed);
+            Detailed.Subscribe(OnDetailed);
+            Detailed.Publish(null, new PayloadData { Value = 1 });
+            Assert.AreEqual("detailed:1,detailed:1", string.Join(",", Log));
+
+            Log.Clear();
+            Detailed.Unsubscribe(OnDetailed);
+            Detailed.Publish(null, new PayloadData { Value = 2 });
+            Assert.AreEqual("detailed:2", string.Join(",", Log), "one unsubscribe must remove only one");
+
+            Log.Clear();
+            Detailed.Unsubscribe(OnDetailed);
+            Detailed.Publish(null, new PayloadData { Value = 3 });
+            Assert.AreEqual("", string.Join(",", Log));
+        }
+
+        [Test]
+        public void UnsubscribingSomethingNeverSubscribed_IsANoOp()
+        {
+            Assert.DoesNotThrow(() => Detailed.Unsubscribe(OnDetailed));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void Reset_DropsTheWrapperTable()
+        {
+            Detailed.Subscribe(OnDetailed);
+            EventsRegistry.ResetStaticState();
+
+            // The publisher's subscriptions are deliberately not cleared by a reset, so a leaked wrapper
+            // entry would survive here and a later Unsubscribe would remove a handler belonging to the
+            // previous play session.
+            Detailed.Unsubscribe(OnDetailed);
+            Detailed.Publish(null, new PayloadData { Value = 5 });
+
+            Assert.AreEqual("detailed:5", string.Join(",", Log),
+                "reset must forget the wrapper, leaving the old subscription for Clear() to deal with");
+        }
+
+        // ---- retained values ----
+
+        [Test]
+        public void TypedHandler_SubscribingLate_GetsTheRetainedPayload()
+        {
+            // Sticky replay runs through the same wrapper as a live publish, so the payload has to
+            // survive the round trip through object and back.
+            Level.Publish(null, new PayloadData { Value = 2 });
+            Level.Subscribe(OnLevel);
+
+            Assert.AreEqual("level:2", string.Join(",", Log));
+        }
+
+        [Test]
+        public void TypedTryGetLast_ReturnsTheRetainedPayload()
+        {
+            Level.Publish(null, new PayloadData { Value = 8 });
+
+            Assert.IsTrue(Level.TryGetLast(out object sender, out PayloadData data));
+            Assert.AreEqual(8, data.Value);
+        }
+
+        [Test]
+        public void TypedTryGetLast_ReportsAndFailsWhenTheRetainedValueIsTheWrongType()
+        {
+            EventsPublisher.StrictMode = false;   // isolate the read-side report from the publish-side one
+            LogAssert.Expect(LogType.Error, new Regex("reading the retained value.*PayloadTestEvents/Level"));
+
+            Bus.PublishEvent(Level.Name, null, "not-a-payload");
+
+            Assert.IsFalse(Level.TryGetLast(out object sender, out PayloadData data));
+            Assert.IsNull(data);
+        }
+
+        [Test]
+        public void TypedTryGetLast_IsFalseWhenNothingWasRetained()
+        {
+            Assert.IsFalse(Level.TryGetLast(out object sender, out PayloadData data));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        // ---- mismatches the compiler cannot catch ----
+
+        [Test]
+        public void TypeArgumentDisagreeingWithTheAttribute_IsReported()
+        {
+            // The one runtime-checked point in the design: where the type argument is written. Getting
+            // it wrong here is a loud error naming both types, not a cast failure inside a handler later.
+            LogAssert.Expect(LogType.Error, new Regex("PayloadTestEvents/Detailed.*already declared to carry"));
+
+            EventsFor<PayloadTestEvents>.Id<string>(PayloadTestEvents.Detailed);
+        }
+
+        [Test]
+        public void TwoCallSitesDisagreeingAboutAnUnannotatedEvent_IsReported()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("Ad/Hoc.*already declared to carry System.Int32"));
+
+            EventId<int>.Of("Ad/Hoc");
+            EventId<string>.Of("Ad/Hoc");
+        }
+
+        [Test]
+        public void RestatingTheSamePayloadType_IsNotAConflict()
+        {
+            EventsFor<PayloadTestEvents>.Id<PayloadData>(PayloadTestEvents.Detailed);
+            EventsFor<PayloadTestEvents>.Id<PayloadData>(PayloadTestEvents.Detailed);
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void UntypedPublishOfTheWrongPayload_IsReportedAtThePublisher()
+        {
+            // Named at the publisher, with the sender, which is the half of the story the handler-side
+            // report cannot tell.
+            LogAssert.Expect(LogType.Error, new Regex("published by probe with a payload of System.String"));
+
+            EventsFor<PayloadTestEvents>.EnsureRegistered();
+            Bus.PublishEvent(Detailed.Name, "probe", "wrong");
+        }
+
+        [Test]
+        public void UntypedPublishOfTheWrongPayload_SkipsTheHandlerRatherThanThrowing()
+        {
+            EventsPublisher.StrictMode = false;
+            LogAssert.Expect(LogType.Error, new Regex("delivering to a handler of.*PayloadTestEvents/Detailed"));
+
+            Detailed.Subscribe(OnDetailed);
+            Assert.DoesNotThrow(() => Bus.PublishEvent(Detailed.Name, null, "wrong"));
+
+            Assert.AreEqual("", string.Join(",", Log), "the handler must not run with a payload it cannot use");
+        }
+
+        [Test]
+        public void UnannotatedEvent_StaysUnchecked()
+        {
+            // The default has to remain "no declaration, no checking", or Stage 3 would start reporting
+            // every event in a project that has not declared anything.
+            EventsFor<PayloadTestEvents>.Publish(PayloadTestEvents.Loose, "probe", "anything at all");
+            EventsFor<PayloadTestEvents>.Publish(PayloadTestEvents.Loose, "probe", 42);
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        // ---- null payloads ----
+
+        [Test]
+        public void NullPayload_ReachesAReferenceTypedHandler()
+        {
+            Detailed.Subscribe(OnDetailed);
+            Detailed.Publish(null, null);
+
+            Assert.AreEqual("detailed:null", string.Join(",", Log));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void NullPayload_IsReportedForAValueTypedEvent()
+        {
+            // Null cannot be an int, so a handler expecting one would otherwise be handed default(int)
+            // and treat a missing payload as a real zero.
+            LogAssert.Expect(LogType.Error, new Regex("payload of null, but it is declared to carry System.Int32"));
+
+            EventsFor<PayloadTestEvents>.EnsureRegistered();
+            Bus.PublishEvent(Counted.Name, "probe", null);
+        }
+
+        [Test]
+        public void NullPayload_IsNotDeliveredAsZeroToAValueTypedHandler()
+        {
+            // The typed API cannot publish null to an EventId<int> — that does not compile — so this is
+            // reachable only from an untyped publish. Handing the handler default(int) would be the worst
+            // outcome available: a missing payload silently read as a real score of zero.
+            EventsPublisher.StrictMode = false;
+            LogAssert.Expect(LogType.Error, new Regex("delivering to a handler of.*PayloadTestEvents/Score"));
+
+            Score.Subscribe(OnScore);
+            Bus.PublishEvent(Score.Name, null, null);
+
+            Assert.AreEqual("", string.Join(",", Log));
+        }
+
+        [Test]
+        public void TypedTryGetLast_DoesNotTurnANullRetainedValueIntoZero()
+        {
+            EventsPublisher.StrictMode = false;
+            LogAssert.Expect(LogType.Error, new Regex("reading the retained value.*PayloadTestEvents/Score"));
+
+            EventsFor<PayloadTestEvents>.EnsureRegistered();
+            Bus.PublishEvent(Score.Name, null, null);
+
+            Assert.IsFalse(Score.TryGetLast(out object sender, out int data));
+            Assert.AreEqual(0, data);
+        }
+
+        [Test]
+        public void ObjectPayloadDeclaration_MeansAnythingGoes()
+        {
+            EventId<object>.Of("Any/Thing").Register();
+            Bus.PublishEvent("Any/Thing", "probe", 1);
+            Bus.PublishEvent("Any/Thing", "probe", "one");
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        // ---- identity ----
+
+        [Test]
+        public void TypedIdentity_WidensToTheUntypedOne()
+        {
+            EventId erased = Detailed;
+
+            Assert.AreEqual(EventsFor<PayloadTestEvents>.GetEventId(PayloadTestEvents.Detailed), erased);
+            Assert.AreEqual(Detailed.Name, erased.Name);
+        }
+
+        [Test]
+        public void DefaultTypedIdentity_IsInvalidAndInert()
+        {
+            EventId<PayloadData> unset = default(EventId<PayloadData>);
+
+            Assert.IsFalse(unset.IsValid);
+            Assert.DoesNotThrow(() => unset.Publish(null, new PayloadData()));
+            Assert.DoesNotThrow(() => unset.Subscribe(OnDetailed));
+            Assert.IsFalse(unset.TryGetLast(out object sender, out PayloadData data));
+        }
+
+        private void OnDetailed(string eventName, object sender, PayloadData data)
+        {
+            Log.Add("detailed:" + (data == null ? "null" : data.Value.ToString()));
+        }
+
+        private void OnLevel(string eventName, object sender, PayloadData data)
+        {
+            Log.Add("level:" + (data == null ? "null" : data.Value.ToString()));
+        }
+
+        private void OnScore(string eventName, object sender, int data)
+        {
+            Log.Add("score:" + data);
+        }
+    }
+}

--- a/Tests/Editor/EventPayloadTests.cs.meta
+++ b/Tests/Editor/EventPayloadTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 571fcb20e9854c4da67da6fe4a435a4f

--- a/Tests/Editor/EventRefTests.cs
+++ b/Tests/Editor/EventRefTests.cs
@@ -1,0 +1,114 @@
+using CrawfisSoftware.Events.Editor;
+
+using NUnit.Framework;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    [EventEnum]
+    public enum PrefixedTestEvents { Alpha }
+
+    namespace Aliased
+    {
+        [EventEnum(Prefix = "AliasedEvents")]
+        public enum PrefixedTestEvents { Alpha }
+    }
+
+    /// <summary>
+    /// The prefix override, and the <see cref="EventRef"/> overloads that keep authored call sites from
+    /// unwrapping the underlying string.
+    /// </summary>
+    public class EventRefTests : EventsTestBase
+    {
+        [Test]
+        public void PrefixOverride_ResolvesACollisionWithoutRenamingTheType()
+        {
+            // Switching the whole scheme to Type.FullName would close this too, but would rename every
+            // event and break every name already baked into a scene or prefab. An override touches only
+            // the enum that collides.
+            Assert.AreEqual("PrefixedTestEvents/Alpha",
+                EventsFor<PrefixedTestEvents>.GetEventName(PrefixedTestEvents.Alpha));
+            Assert.AreEqual("AliasedEvents/Alpha",
+                EventsFor<Aliased.PrefixedTestEvents>.GetEventName(Aliased.PrefixedTestEvents.Alpha));
+        }
+
+        [Test]
+        public void PrefixOverride_MeansNoCollisionIsReported()
+        {
+            EventsFor<PrefixedTestEvents>.EnsureRegistered();
+            EventsFor<Aliased.PrefixedTestEvents>.EnsureRegistered();
+
+            // Same simple type name, different namespaces — but no longer the same prefix.
+            UnityEngine.TestTools.LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void CatalogHonoursThePrefixOverride()
+        {
+            string[] names = EventNameCatalog.BuildNames(new[] { typeof(Aliased.PrefixedTestEvents) });
+
+            Assert.AreEqual(1, names.Length);
+            Assert.AreEqual("AliasedEvents/Alpha", names[0]);
+        }
+
+        [Test]
+        public void EventRef_ProjectsTheSameNameAsTheFacade()
+        {
+            EventRef reference = EventRef.For(PrefixedTestEvents.Alpha);
+
+            Assert.AreEqual(EventsFor<PrefixedTestEvents>.GetEventName(PrefixedTestEvents.Alpha), reference.Name);
+            Assert.IsFalse(reference.IsEmpty);
+        }
+
+        [Test]
+        public void EventRef_RoundTripsBackToItsEnum()
+        {
+            EventRef reference = EventRef.For(PrefixedTestEvents.Alpha);
+
+            Assert.IsTrue(reference.TryGetEnum(out PrefixedTestEvents value));
+            Assert.AreEqual(PrefixedTestEvents.Alpha, value);
+        }
+
+        [Test]
+        public void EventRefOverloads_PublishAndSubscribe()
+        {
+            EventRef reference = EventRef.For(PrefixedTestEvents.Alpha);
+
+            Bus.SubscribeToEvent(reference, Recorder("ref"));
+            Bus.PublishEvent(reference, null, "payload");
+
+            Assert.AreEqual("ref:payload", string.Join(",", Log));
+        }
+
+        [Test]
+        public void EventRefOverloads_IgnoreAnUnsetReference()
+        {
+            EventsPublisher.StrictMode = false;
+            var unset = default(EventRef);
+
+            // A component unsubscribing an optional event in OnDestroy would otherwise need its own
+            // guard, and forgetting it is exactly how a null name reached Dictionary.ContainsKey.
+            Assert.IsTrue(unset.IsEmpty);
+            Assert.DoesNotThrow(() =>
+            {
+                Bus.SubscribeToEvent(unset, Recorder("x"));
+                Bus.PublishEvent(unset, null, null);
+                Bus.UnsubscribeToEvent(unset, Recorder("x"));
+            });
+            Assert.IsFalse(Bus.TryGetLast(unset, out _, out _));
+        }
+
+        [Test]
+        public void EventRefOverloads_CarryDeliveryPolicy()
+        {
+            EventRef reference = EventRef.For(PrefixedTestEvents.Alpha);
+            Bus.RegisterEvent(reference, EventDelivery.Sticky);
+
+            Bus.PublishEvent(reference, null, "retained");
+            Bus.SubscribeToEvent(reference, Recorder("late"));
+
+            Assert.AreEqual("late:retained", string.Join(",", Log));
+            Assert.IsTrue(Bus.TryGetLast(reference, out _, out object data));
+            Assert.AreEqual("retained", data);
+        }
+    }
+}

--- a/Tests/Editor/EventRefTests.cs.meta
+++ b/Tests/Editor/EventRefTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f8bb25a3e31b405f99ea6be3122034e5

--- a/Tests/Editor/EventsDiagnosticsTests.cs
+++ b/Tests/Editor/EventsDiagnosticsTests.cs
@@ -1,0 +1,119 @@
+using NUnit.Framework;
+
+using UnityEngine.TestTools;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    public enum DiagnosticTestEvents
+    {
+        Transient,
+
+        [EventDelivery(EventDelivery.Sticky)]
+        Retained,
+    }
+
+    /// <summary>
+    /// The late-delivery recorder that turns the edge-or-level decision into a measurement.
+    /// </summary>
+    /// <remarks>Its usefulness rests entirely on being quiet. An event reported here is one a project
+    /// will spend real time reasoning about, so the tests are mostly about what must <em>not</em> be
+    /// reported.</remarks>
+    public class EventsDiagnosticsTests : EventsTestBase
+    {
+        private static readonly string TransientName =
+            EventsFor<DiagnosticTestEvents>.GetEventName(DiagnosticTestEvents.Transient);
+
+        [Test]
+        public void SubscribingAfterAPublish_IsRecordedAsLate()
+        {
+            EventsFor<DiagnosticTestEvents>.Publish(DiagnosticTestEvents.Transient, null, "v");
+            EventsFor<DiagnosticTestEvents>.Subscribe(DiagnosticTestEvents.Transient, Recorder("late"));
+
+            var late = EventsDiagnostics.GetLateDeliveries();
+            Assert.AreEqual(1, late.Count);
+            Assert.AreEqual(TransientName, late[0].Name);
+            Assert.AreEqual(1, late[0].LateSubscribes);
+            Assert.AreEqual(1, late[0].Publishes);
+            Assert.AreEqual("", string.Join(",", Log), "a transient event delivers nothing to a late subscriber");
+        }
+
+        [Test]
+        public void SubscribingBeforeAnyPublish_IsNotLate()
+        {
+            // The check the whole diagnostic depends on. Counting every subscribe would list every event
+            // in the project, and a report that flags everything is one nobody can act on.
+            EventsFor<DiagnosticTestEvents>.Subscribe(DiagnosticTestEvents.Transient, Recorder("early"));
+            EventsFor<DiagnosticTestEvents>.Publish(DiagnosticTestEvents.Transient, null, "v");
+
+            Assert.AreEqual(0, EventsDiagnostics.GetLateDeliveries().Count);
+            Assert.AreEqual("early:v", string.Join(",", Log));
+        }
+
+        [Test]
+        public void ASubscriberArrivingLateToAStickyEvent_IsNotLate()
+        {
+            // It was delivered the retained value, so nothing was missed. Reporting it would tell a
+            // project to make Sticky what is already Sticky.
+            EventsFor<DiagnosticTestEvents>.Publish(DiagnosticTestEvents.Retained, null, "v");
+            EventsFor<DiagnosticTestEvents>.Subscribe(DiagnosticTestEvents.Retained, Recorder("late"));
+
+            Assert.AreEqual(0, EventsDiagnostics.GetLateDeliveries().Count);
+            Assert.AreEqual("late:v", string.Join(",", Log));
+        }
+
+        [Test]
+        public void APublishIsCountedOncePerPublish_NotOncePerPublisherFrame()
+        {
+            EventsPublisher.Instance.Push();
+            EventsFor<DiagnosticTestEvents>.Publish(DiagnosticTestEvents.Transient, null, "v");
+            EventsFor<DiagnosticTestEvents>.Subscribe(DiagnosticTestEvents.Transient, Recorder("late"));
+
+            var late = EventsDiagnostics.GetLateDeliveries();
+            Assert.AreEqual(1, late.Count);
+            Assert.AreEqual(1, late[0].Publishes, "the stack dispatches to every frame; that is one publish");
+
+            EventsPublisher.Instance.Pop();
+        }
+
+        [Test]
+        public void Disabled_RecordsNothing()
+        {
+            EventsDiagnostics.Enabled = false;
+
+            EventsFor<DiagnosticTestEvents>.Publish(DiagnosticTestEvents.Transient, null, "v");
+            EventsFor<DiagnosticTestEvents>.Subscribe(DiagnosticTestEvents.Transient, Recorder("late"));
+
+            Assert.AreEqual(0, EventsDiagnostics.GetAll().Count);
+        }
+
+        [Test]
+        public void Reset_DiscardsWhatWasRecorded()
+        {
+            EventsFor<DiagnosticTestEvents>.Publish(DiagnosticTestEvents.Transient, null, "v");
+            EventsFor<DiagnosticTestEvents>.Subscribe(DiagnosticTestEvents.Transient, Recorder("late"));
+            Assert.AreEqual(1, EventsDiagnostics.GetLateDeliveries().Count);
+
+            EventsDiagnostics.Reset();
+
+            Assert.AreEqual(0, EventsDiagnostics.GetAll().Count);
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void MostAffectedEventIsReportedFirst()
+        {
+            EventsPublisher.Instance.RegisterEvent("Diag/Once");
+            EventsPublisher.Instance.PublishEvent("Diag/Once", null, null);
+            EventsPublisher.Instance.SubscribeToEvent("Diag/Once", Recorder("a"));
+
+            EventsPublisher.Instance.RegisterEvent("Diag/Twice");
+            EventsPublisher.Instance.PublishEvent("Diag/Twice", null, null);
+            EventsPublisher.Instance.SubscribeToEvent("Diag/Twice", Recorder("b"));
+            EventsPublisher.Instance.SubscribeToEvent("Diag/Twice", Recorder("c"));
+
+            var late = EventsDiagnostics.GetLateDeliveries();
+            Assert.AreEqual(2, late.Count);
+            Assert.AreEqual("Diag/Twice", late[0].Name, "the worst offender must lead the report");
+        }
+    }
+}

--- a/Tests/Editor/EventsDiagnosticsTests.cs.meta
+++ b/Tests/Editor/EventsDiagnosticsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 869b00d107624126be77664287fad35b

--- a/Tests/Editor/EventsForTests.cs
+++ b/Tests/Editor/EventsForTests.cs
@@ -1,0 +1,131 @@
+using System.Text.RegularExpressions;
+
+using NUnit.Framework;
+
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    [EventEnum]
+    public enum SweptTestEvents { One, Two }
+
+    public enum LazyTestEvents { Alpha, Beta }
+
+    namespace CollidingA { public enum SameNameEvents { Alpha } }
+    namespace CollidingB { public enum SameNameEvents { Alpha } }
+
+    /// <summary>
+    /// The static facade: registration timing, family scoping, cross-family collisions, and reset.
+    /// </summary>
+    public class EventsForTests : EventsTestBase
+    {
+        [Test]
+        public void FirstTouch_RegistersTheWholeFamily_WithNoSceneObject()
+        {
+            // No Awake, no [DefaultExecutionOrder], no GameObject. Any publish or subscribe goes through
+            // EventsFor<T>, so registration always precedes first use.
+            EventsFor<LazyTestEvents>.Subscribe(LazyTestEvents.Alpha, Recorder("late"));
+            EventsFor<LazyTestEvents>.Publish(LazyTestEvents.Alpha, null, "v");
+
+            Assert.AreEqual("late:v", string.Join(",", Log));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void ProjectedName_IsTypeNameSlashMemberName()
+        {
+            Assert.AreEqual("LazyTestEvents/Alpha", EventsFor<LazyTestEvents>.GetEventName(LazyTestEvents.Alpha));
+        }
+
+        [Test]
+        public void TryGetEnum_RoundTripsWithoutParsing()
+        {
+            string name = EventsFor<LazyTestEvents>.GetEventName(LazyTestEvents.Beta);
+
+            Assert.IsTrue(EventsFor<LazyTestEvents>.TryGetEnum(name, out LazyTestEvents value));
+            Assert.AreEqual(LazyTestEvents.Beta, value);
+        }
+
+        [Test]
+        public void TryGetEnum_RejectsForeignAndNullNames()
+        {
+            Assert.IsFalse(EventsFor<LazyTestEvents>.TryGetEnum("SomeOther/Beta", out _));
+            Assert.IsFalse(EventsFor<LazyTestEvents>.TryGetEnum(null, out _));
+        }
+
+        [Test]
+        public void RawStringPublish_IsFlaggedBeforeTheSweepAndCleanAfter()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("SweptTestEvents/One.*is not registered"));
+            Bus.PublishEvent("SweptTestEvents/One", "probe", null);
+
+            // [EventEnum] covers the one case lazy initialization cannot: a name reaching the publisher
+            // as a raw string, from a serialized Inspector field, without the facade ever being touched.
+            EventsRegistry.RegisterAnnotatedEventEnums();
+
+            Bus.PublishEvent("SweptTestEvents/One", "probe", null);
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void SubscribeToAll_IsScopedToItsOwnFamily()
+        {
+            EventsFor<LazyTestEvents>.SubscribeToAll(Recorder("lazy"));
+
+            EventsFor<LazyTestEvents>.Publish(LazyTestEvents.Beta, null, "mine");
+            EventsFor<SweptTestEvents>.Publish(SweptTestEvents.Two, null, "theirs");
+
+            Assert.AreEqual("lazy:mine", string.Join(",", Log));
+        }
+
+        [Test]
+        public void UnsubscribeFromAll_RemovesEveryMember()
+        {
+            System.Action<string, object, object> callback = Recorder("lazy");
+            EventsFor<LazyTestEvents>.SubscribeToAll(callback);
+            EventsFor<LazyTestEvents>.UnsubscribeFromAll(callback);
+
+            EventsFor<LazyTestEvents>.Publish(LazyTestEvents.Beta, null, "mine");
+
+            Assert.AreEqual(0, Log.Count);
+        }
+
+        [Test]
+        public void TwoEnumTypesWithTheSameSimpleName_AreReportedAsColliding()
+        {
+            // Names project from Type.Name, not Type.FullName, so these share every event.
+            // This check lived on the generic type until it was noticed that a static field inside a
+            // generic exists per constructed type — so each closed type saw only its own prefix and the
+            // cross-type comparison could never fire.
+            LogAssert.Expect(LogType.Error, new Regex("both project onto the event name prefix 'SameNameEvents/'"));
+
+            EventsFor<CollidingA.SameNameEvents>.EnsureRegistered();
+            EventsFor<CollidingB.SameNameEvents>.EnsureRegistered();
+        }
+
+        [Test]
+        public void SameEnumTypeReRegistering_IsNotACollision()
+        {
+            // Must stay idempotent: statics survive a domain reload when the project disables it.
+            EventsFor<LazyTestEvents>.EnsureRegistered();
+            EventsFor<LazyTestEvents>.EnsureRegistered();
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void Reset_DropsCachedFacadesAndRebuildsOnNextUse()
+        {
+            EventsFor<LazyTestEvents>.EnsureRegistered();
+
+            EventsRegistry.ResetStaticState();
+
+            EventsFor<LazyTestEvents>.Subscribe(LazyTestEvents.Alpha, Recorder("after"));
+            EventsFor<LazyTestEvents>.Publish(LazyTestEvents.Alpha, null, "v");
+
+            Assert.AreEqual("after:v", string.Join(",", Log));
+            LogAssert.NoUnexpectedReceived();
+        }
+    }
+}

--- a/Tests/Editor/EventsForTests.cs.meta
+++ b/Tests/Editor/EventsForTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cfc5320529f142ea9843a588df67ea4d

--- a/Tests/Editor/EventsPublisherTests.cs
+++ b/Tests/Editor/EventsPublisherTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Text.RegularExpressions;
+
+using NUnit.Framework;
+
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    /// <summary>
+    /// Dispatch behaviour of the publisher itself: ordering, isolation, and the strict-mode diagnostic.
+    /// </summary>
+    public class EventsPublisherTests : EventsTestBase
+    {
+        [Test]
+        public void NestedPublish_RunsCurrentEventsHandlersFirst()
+        {
+            Bus.RegisterEvent("A");
+            Bus.RegisterEvent("B");
+            Bus.SubscribeToEvent("A", (e, s, d) => { Log.Add("A1"); Bus.PublishEvent("B", null, null); });
+            Bus.SubscribeToEvent("A", (e, s, d) => Log.Add("A2"));
+            Bus.SubscribeToEvent("B", (e, s, d) => Log.Add("B1"));
+
+            Bus.PublishEvent("A", null, null);
+
+            // A callback that publishes must not pre-empt the remaining callbacks for the current event.
+            Assert.AreEqual("A1,A2,B1", string.Join(",", Log));
+        }
+
+        [Test]
+        public void NestedPublish_TwoLevelsDeep_StaysBreadthFirst()
+        {
+            Bus.RegisterEvent("A");
+            Bus.RegisterEvent("B");
+            Bus.RegisterEvent("C");
+            Bus.SubscribeToEvent("A", (e, s, d) => { Log.Add("A1"); Bus.PublishEvent("B", null, null); });
+            Bus.SubscribeToEvent("A", (e, s, d) => Log.Add("A2"));
+            Bus.SubscribeToEvent("B", (e, s, d) => { Log.Add("B1"); Bus.PublishEvent("C", null, null); });
+            Bus.SubscribeToEvent("C", (e, s, d) => Log.Add("C1"));
+
+            Bus.PublishEvent("A", null, null);
+
+            Assert.AreEqual("A1,A2,B1,C1", string.Join(",", Log));
+        }
+
+        [Test]
+        public void ThrowingHandler_DoesNotStopLaterHandlers()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("Exception publishing C"));
+            Bus.RegisterEvent("C");
+            Bus.SubscribeToEvent("C", (e, s, d) => throw new InvalidOperationException("boom"));
+            Bus.SubscribeToEvent("C", Recorder("after"));
+
+            Bus.PublishEvent("C", null, null);
+
+            Assert.AreEqual(1, Log.Count, "the handler after the throwing one should still run");
+        }
+
+        [Test]
+        public void ThrowingHandler_DoesNotPoisonTheNextPublish()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("Exception publishing C"));
+            LogAssert.Expect(LogType.Error, new Regex("Exception publishing C"));
+            Bus.RegisterEvent("C");
+            Bus.SubscribeToEvent("C", (e, s, d) => throw new InvalidOperationException("boom"));
+            Bus.SubscribeToEvent("C", Recorder("after"));
+
+            Bus.PublishEvent("C", null, null);
+            Log.Clear();
+            Bus.PublishEvent("C", null, null);
+
+            // A stranded queue entry would deliver twice here.
+            Assert.AreEqual(1, Log.Count, "the second publish should deliver exactly once");
+        }
+
+        [Test]
+        public void WrongPayloadCast_IsContainedInTheHandler()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("Exception publishing D"));
+            Bus.RegisterEvent("D");
+            Bus.SubscribeToEvent("D", (e, s, d) => Log.Add("int=" + (int)d));
+
+            // Publishing the wrong payload type must not take the publisher down. Making this a compile
+            // error rather than a swallowed runtime one is Stage 3 of the identity work.
+            Assert.DoesNotThrow(() => Bus.PublishEvent("D", null, "not-an-int"));
+        }
+
+        [Test]
+        public void StrictMode_ReportsAnUnregisteredPublish()
+        {
+            // Without this the publish silently reaches no targeted subscriber while still notifying
+            // "all events" subscribers, so the logger prints it and the system looks healthy.
+            LogAssert.Expect(LogType.Error, new Regex("GameFlowEvents/Typoo.*is not registered"));
+
+            Bus.PublishEvent("GameFlowEvents/Typoo", "probe", null);
+        }
+
+        [Test]
+        public void StrictMode_DoesNotReportAnEventRegisteredOnALowerFrame()
+        {
+            Bus.RegisterEvent("OnLowerFrame");
+            Bus.Push();
+            try
+            {
+                // RegisterEvent reaches only the top frame while PublishEvent visits every frame, so a
+                // per-frame check would report a false positive for every frame below the registration.
+                Bus.PublishEvent("OnLowerFrame", "probe", null);
+                LogAssert.NoUnexpectedReceived();
+            }
+            finally
+            {
+                Bus.Pop();
+            }
+        }
+
+        [Test]
+        public void NullAndEmptyEventNames_AreRejectedRatherThanThrowing()
+        {
+            EventsPublisher.StrictMode = false;
+
+            // FireEventAfterSceneLoads.OnDestroy unsubscribes its reset event unconditionally, even when
+            // the field is null. Dictionary.ContainsKey(null) throws ArgumentNullException.
+            Assert.DoesNotThrow(() =>
+            {
+                Bus.UnsubscribeToEvent(null, Recorder("x"));
+                Bus.SubscribeToEvent(null, Recorder("x"));
+                Bus.PublishEvent(null, null, null);
+                Bus.RegisterEvent(string.Empty);
+            });
+        }
+
+        [Test]
+        public void AllEventsSubscriber_StillSeesEveryEvent()
+        {
+            // The global logger, EventHistory and DebugEventFileLogger all depend on this channel.
+            Bus.SubscribeToAllEvents(Recorder("all"));
+            Bus.RegisterEvent("E");
+
+            Bus.PublishEvent("E", null, "payload");
+
+            Assert.AreEqual("all:payload", string.Join(",", Log));
+        }
+    }
+}

--- a/Tests/Editor/EventsPublisherTests.cs.meta
+++ b/Tests/Editor/EventsPublisherTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 618845b5420c4314acef60882a531304

--- a/Tests/Editor/EventsTestBase.cs
+++ b/Tests/Editor/EventsTestBase.cs
@@ -30,7 +30,10 @@ namespace CrawfisSoftware.Events.Tests
         {
             ResetEverything();
             Log = new List<string>();
+            // Set rather than assumed: both default off outside the editor, and a test that depended on
+            // a compile symbol would pass here and fail in a player build of the same suite.
             EventsPublisher.StrictMode = true;
+            EventsDiagnostics.Enabled = true;
         }
 
         [TearDown]

--- a/Tests/Editor/EventsTestBase.cs
+++ b/Tests/Editor/EventsTestBase.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    /// <summary>
+    /// Shared setup for the events tests.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="EventsPublisher"/> is a process-wide singleton and <see cref="EventsRegistry"/> holds
+    /// static state, so tests would otherwise leak subscriptions, retained values and declared policies
+    /// into each other. Every fixture resets both before and after each test.
+    /// </remarks>
+    public abstract class EventsTestBase
+    {
+        /// <summary>Collects handler invocations as <c>"tag:data"</c> so order can be asserted.</summary>
+        protected List<string> Log { get; private set; }
+
+        protected static IStackEventsPublisher<string> Bus => EventsPublisher.Instance;
+
+        /// <summary>A callback that records its invocation, for asserting delivery and ordering.</summary>
+        protected System.Action<string, object, object> Recorder(string tag)
+        {
+            return (eventName, sender, data) => Log.Add(tag + ":" + (data ?? "-"));
+        }
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            ResetEverything();
+            Log = new List<string>();
+            EventsPublisher.StrictMode = true;
+        }
+
+        [TearDown]
+        public virtual void TearDown()
+        {
+            ResetEverything();
+        }
+
+        private static void ResetEverything()
+        {
+            EventsPublisher.Instance.Clear();
+            // Drops declared policies, claimed prefixes, and every cached EventsFor<T> facade.
+            EventsRegistry.ResetStaticState();
+        }
+    }
+}

--- a/Tests/Editor/EventsTestBase.cs.meta
+++ b/Tests/Editor/EventsTestBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 18a58af1559c416f95437983d8242bbb

--- a/Tests/Editor/EventsUpgradeAuditTests.cs
+++ b/Tests/Editor/EventsUpgradeAuditTests.cs
@@ -72,6 +72,52 @@ namespace CrawfisSoftware.Events.Tests
         }
 
         [Test]
+        public void PackageInDependenciesOnly_IsNotListedInTestables()
+        {
+            // The regression this check exists for. A substring search over the whole manifest matches
+            // the package's own dependencies entry, which every consuming project has, so the audit
+            // reported testables as configured in a project whose manifest had no testables key at all.
+            const string manifest = @"{ ""dependencies"": { ""com.crawfissoftware.eventspublisher"": ""https://x.git"" } }";
+
+            Assert.IsFalse(EventsUpgradeAudit.IsListedInTestables(manifest, "com.crawfissoftware.eventspublisher"));
+        }
+
+        [Test]
+        public void PackageInTestables_IsListed()
+        {
+            const string manifest = @"{ ""dependencies"": { ""com.crawfissoftware.eventspublisher"": ""https://x.git"" },
+                                        ""testables"": [ ""com.crawfissoftware.eventspublisher"" ] }";
+
+            Assert.IsTrue(EventsUpgradeAudit.IsListedInTestables(manifest, "com.crawfissoftware.eventspublisher"));
+        }
+
+        [Test]
+        public void ADifferentPackageInTestables_IsNotAMatch()
+        {
+            const string manifest = @"{ ""testables"": [ ""com.other.package"" ] }";
+
+            Assert.IsFalse(EventsUpgradeAudit.IsListedInTestables(manifest, "com.crawfissoftware.eventspublisher"));
+        }
+
+        [Test]
+        public void APackageWhoseNameIsAPrefixOfAListedOne_IsNotAMatch()
+        {
+            // Matching the bare name rather than the quoted one makes every prefix a false positive.
+            const string manifest = @"{ ""testables"": [ ""com.crawfissoftware.eventspublisher.extras"" ] }";
+
+            Assert.IsFalse(EventsUpgradeAudit.IsListedInTestables(manifest, "com.crawfissoftware.eventspublisher"));
+        }
+
+        [Test]
+        public void AMalformedOrAbsentManifest_IsNotListed()
+        {
+            Assert.IsFalse(EventsUpgradeAudit.IsListedInTestables(null, "com.x"));
+            Assert.IsFalse(EventsUpgradeAudit.IsListedInTestables("", "com.x"));
+            Assert.IsFalse(EventsUpgradeAudit.IsListedInTestables(@"{ ""testables"":", "com.x"));
+            Assert.IsFalse(EventsUpgradeAudit.IsListedInTestables(@"{ ""testables"": [ ""com.x""", "com.x"));
+        }
+
+        [Test]
         public void UnmarkedEventEnum_IsReportedByName()
         {
             var input = new UpgradeAuditInput

--- a/Tests/Editor/EventsUpgradeAuditTests.cs
+++ b/Tests/Editor/EventsUpgradeAuditTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using UnityEngine;
+using UnityEngine.TestTools;
+
+using CrawfisSoftware.Events.Editor;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    [EventEnum]
+    public enum AuditMarkedEvents
+    {
+        [EventDelivery(EventDelivery.Sticky)]
+        [EventPayload(typeof(string))]
+        ConfigLoaded,
+
+        Jumped,
+    }
+
+    public enum AuditUnmarkedEvents { ServicesInitialized, Failing }
+
+    /// <summary>Stands in for a consuming project's component, for the serialized-field checks.</summary>
+    public class AuditProbeComponent
+    {
+        [SerializeField] private string _eventToFire = null;
+        [SerializeField] private string _trigger = null;
+        [EventName] [SerializeField] private string _alreadyMarked = null;
+        [SerializeField] private string _unrelatedLabel = null;
+    }
+
+    /// <summary>
+    /// The upgrade audit's reasoning. Gathering is an editor concern and is not covered here; what a
+    /// given project state should produce is.
+    /// </summary>
+    public class EventsUpgradeAuditTests : EventsTestBase
+    {
+        private static FieldInfo Field(string name)
+        {
+            return typeof(AuditProbeComponent).GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+        }
+
+        private static UpgradeFinding Step(List<UpgradeFinding> findings, string stepPrefix)
+        {
+            foreach (UpgradeFinding finding in findings)
+                if (finding.Step.StartsWith(stepPrefix, StringComparison.Ordinal)) return finding;
+            throw new AssertionException("no finding for step " + stepPrefix);
+        }
+
+        private static string Joined(UpgradeFinding finding)
+        {
+            return string.Join(" | ", finding.Details);
+        }
+
+        [Test]
+        public void MissingTestables_IsAnAction()
+        {
+            var input = new UpgradeAuditInput { TestablesConfigured = false };
+
+            Assert.AreEqual(UpgradeSeverity.Action, Step(EventsUpgradeAudit.Analyze(input), "1.").Severity);
+        }
+
+        [Test]
+        public void ConfiguredTestables_IsOk()
+        {
+            var input = new UpgradeAuditInput { TestablesConfigured = true };
+
+            Assert.AreEqual(UpgradeSeverity.Ok, Step(EventsUpgradeAudit.Analyze(input), "1.").Severity);
+        }
+
+        [Test]
+        public void UnmarkedEventEnum_IsReportedByName()
+        {
+            var input = new UpgradeAuditInput
+            {
+                EventEnums = new[] { typeof(AuditMarkedEvents), typeof(AuditUnmarkedEvents) },
+            };
+
+            UpgradeFinding finding = Step(EventsUpgradeAudit.Analyze(input), "2.");
+            Assert.AreEqual(UpgradeSeverity.Action, finding.Severity);
+            Assert.AreEqual(1, finding.Details.Count, "only the unmarked enum should be listed");
+            Assert.IsTrue(Joined(finding).Contains("AuditUnmarkedEvents"));
+        }
+
+        [Test]
+        public void AllEnumsMarked_IsOk()
+        {
+            var input = new UpgradeAuditInput { EventEnums = new[] { typeof(AuditMarkedEvents) } };
+
+            Assert.AreEqual(UpgradeSeverity.Ok, Step(EventsUpgradeAudit.Analyze(input), "2.").Severity);
+        }
+
+        [Test]
+        public void SerializedFieldHoldingAnEventName_IsReportedEvenWhenItsNameSaysNothing()
+        {
+            // The check that has no heuristic in it. A field called _trigger is invisible to any amount
+            // of guessing from field names, and is found because an asset holds an event name in it.
+            var input = new UpgradeAuditInput
+            {
+                SerializedStringFields = new[] { Field("_trigger"), Field("_unrelatedLabel") },
+                SerializedEventNames = new[]
+                {
+                    new SerializedEventName("Assets/Main.unity", "_trigger", "AuditMarkedEvents/Jumped"),
+                },
+            };
+
+            UpgradeFinding finding = Step(EventsUpgradeAudit.Analyze(input), "3.");
+            Assert.AreEqual(UpgradeSeverity.Action, finding.Severity);
+            Assert.AreEqual(1, finding.Details.Count, "_unrelatedLabel holds no event name and is not guessable");
+            Assert.IsTrue(Joined(finding).Contains("_trigger"));
+        }
+
+        [Test]
+        public void FieldNamedLikeAnEvent_IsOnlyASuggestion()
+        {
+            // Nothing in any asset confirms this one, so it is a guess and must not be presented as more.
+            var input = new UpgradeAuditInput { SerializedStringFields = new[] { Field("_eventToFire") } };
+
+            UpgradeFinding finding = Step(EventsUpgradeAudit.Analyze(input), "3.");
+            Assert.AreEqual(UpgradeSeverity.Suggestion, finding.Severity);
+            Assert.IsTrue(Joined(finding).Contains("_eventToFire"));
+        }
+
+        [Test]
+        public void AlreadyMarkedField_IsNotReported()
+        {
+            var input = new UpgradeAuditInput
+            {
+                SerializedStringFields = new[] { Field("_alreadyMarked") },
+                SerializedEventNames = new[]
+                {
+                    new SerializedEventName("Assets/Main.unity", "_alreadyMarked", "AuditMarkedEvents/Jumped"),
+                },
+            };
+
+            Assert.AreEqual(UpgradeSeverity.Ok, Step(EventsUpgradeAudit.Analyze(input), "3.").Severity);
+        }
+
+        [Test]
+        public void UndeclaredDeliveryPolicies_AreCountedAndLevelsGuessedAt()
+        {
+            var input = new UpgradeAuditInput { EventEnums = new[] { typeof(AuditUnmarkedEvents) } };
+
+            UpgradeFinding finding = Step(EventsUpgradeAudit.Analyze(input), "6. Delivery");
+            Assert.AreEqual(UpgradeSeverity.Suggestion, finding.Severity, "edge-or-level is a judgement, never an instruction");
+            Assert.IsTrue(finding.Summary.Contains("2 of 2"));
+            Assert.IsTrue(Joined(finding).Contains("ServicesInitialized"), "a level-sounding name should be suggested");
+            Assert.IsFalse(Joined(finding).Contains("Failing"), "an edge-sounding name should not be");
+        }
+
+        [Test]
+        public void SingletonSubclasses_AreReportedWithTheirExecutionOrder()
+        {
+            var input = new UpgradeAuditInput { SingletonSubclasses = new[] { typeof(AuditOrderedSingleton) } };
+
+            UpgradeFinding finding = Step(EventsUpgradeAudit.Analyze(input), "4.");
+            Assert.AreEqual(UpgradeSeverity.Action, finding.Severity);
+            Assert.IsTrue(Joined(finding).Contains("DefaultExecutionOrder"));
+        }
+
+        [Test]
+        public void NoRuntimeData_SaysSoRatherThanReportingACleanRun()
+        {
+            var input = new UpgradeAuditInput { DiagnosticsHaveData = false };
+
+            UpgradeFinding finding = Step(EventsUpgradeAudit.Analyze(input), "6. Delivery (evidence)");
+            Assert.AreEqual(UpgradeSeverity.Suggestion, finding.Severity);
+            Assert.IsTrue(finding.Summary.Contains("No runtime data"));
+        }
+
+        [Test]
+        public void RecordedLateDeliveries_AreReportedAsTheStickyCandidates()
+        {
+            EventsPublisher.Instance.RegisterEvent("Audit/Late");
+            EventsPublisher.Instance.PublishEvent("Audit/Late", null, null);
+            EventsPublisher.Instance.SubscribeToEvent("Audit/Late", Recorder("late"));
+
+            var input = new UpgradeAuditInput
+            {
+                DiagnosticsHaveData = true,
+                LateDeliveries = EventsDiagnostics.GetLateDeliveries(),
+            };
+
+            UpgradeFinding finding = Step(EventsUpgradeAudit.Analyze(input), "6. Delivery (evidence)");
+            Assert.AreEqual(UpgradeSeverity.Action, finding.Severity);
+            Assert.IsTrue(Joined(finding).Contains("Audit/Late"));
+        }
+
+        [Test]
+        public void FindingsAreOrderedMostUrgentFirst()
+        {
+            var input = new UpgradeAuditInput
+            {
+                TestablesConfigured = true,                              // Ok
+                EventEnums = new[] { typeof(AuditUnmarkedEvents) },      // Action + Suggestion
+            };
+
+            List<UpgradeFinding> findings = EventsUpgradeAudit.Analyze(input);
+            for (int i = 1; i < findings.Count; i++)
+                Assert.IsTrue(findings[i - 1].Severity >= findings[i].Severity, "findings must not un-sort");
+        }
+    }
+
+    [UnityEngine.DefaultExecutionOrder(-10000)]
+    public class AuditOrderedSingleton { }
+}

--- a/Tests/Editor/EventsUpgradeAuditTests.cs.meta
+++ b/Tests/Editor/EventsUpgradeAuditTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 84820922df90472ca03816f2b8fbb7b1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.crawfissoftware.eventspublisher",
   "displayName": "Events Publisher",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "unity": "2022.3",
   "description": "Lightweight, allocation-safe event/messaging publisher for Unity projects. Editor tooling included.",
   "keywords": [ "events", "messaging", "publisher", "observer", "csharp", "unity" ],

--- a/package.json
+++ b/package.json
@@ -17,12 +17,5 @@
   "changelogUrl": "https://github.com/crawfis/eventspublisher/releases",
   "licensesUrl": "https://github.com/crawfis/eventspublisher/blob/main/LICENSE",
   "dependencies": {
-  },
-  "samples": [
-    {
-      "displayName": "Basic Usage",
-      "description": "Minimal scene and scripts demonstrating publish/subscribe setup.",
-      "path": "Samples~/Basic Usage"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Addresses two problems that get discussed together but have different causes and different fixes, recorded in `Documentation~/adr/0001-event-identity-and-delivery.md`.

1. **Identity** — the string *is* the event identity, so nothing checks that a call site reproduced it correctly.
2. **Timing** — under additive scene loading a subscriber's `Awake` may run after an event was published, so it never sees it. Worked around today by mirroring events into static `bool`s and polling them.

The reframe running through both: **the string should be a projection, not the identity.** It exists to serve the *observation* side — `SubscribeToAllEvents` feeds the logger, `EventHistory`, `DebugEventFileLogger`. Erase at the observation boundary, not the publication boundary, and the global logger survives untouched.

---

## What's implemented

### Stage 0 — make the hazard loud

- **`EventsPublisher.StrictMode`** (editor/dev builds): publishing a name no frame has registered is reported. Previously it skipped every targeted callback while still notifying "all events" subscribers — so the logger printed it and the system looked healthy. Checked at the **stack** level, since `RegisterEvent` reaches only the top frame while `PublishEvent` visits every frame.
- **`DynamicInvoke` → direct cast invoke.** Removes a reflection dispatch and an `object[]` allocation per callback per publish.
- **Drain hardening**, **null/empty name guards**, **allocation-free `TryGetEnum`/`GetEventName`**.

### `EventsFor<T>` — static facade

`EventsPublisherEnumsSingleton<T>` needs a GameObject and assigns `Instance` in `Awake`, which is what the four `[DefaultExecutionOrder(-10000)]` attributes exist for. That attribute orders `Awake` *within a scene load batch*; an additively-loaded scene is a separate batch, so a scene loaded first will `NullReferenceException` on `Instance`.

`EventsFor<T>` is static and lazily initialized, so the race cannot occur: any publish or subscribe registers the family on first touch. The singleton now forwards to it, so both paths share one facade and existing scene objects keep working unchanged.

### Delivery policy

`EventDelivery` (`Transient`/`Sticky`/`Replay`) via `[EventDelivery(...)]`, read once at facade construction.

```csharp
[EventEnum]
public enum TempleRunEvents
{
    PlayerFailingAtTurn = 12,                              // edge  -> Transient
    [EventDelivery(EventDelivery.Sticky)] PlayerDied = 5,  // level -> retained
}
```

A late subscriber is delivered the retained value **immediately on subscribe, with the payload** — which a `bool` mirror never could. Policy registry is stack-global; retained values are per-frame. `TryGetLast` reads without subscribing.

### Inspector authoring

Scene data has no compile step, so a `[SerializeField] string` event name has no check of any kind.

```csharp
[EventName] [SerializeField] private string _eventToFire;   // existing fields — zero migration
[SerializeField] private EventRef _eventToFire;             // new fields
```

`[EventName]` is the route for existing fields: converting a `string` to `EventRef` changes the serialized shape, so Unity cannot carry the value across and every name baked into a `.unity`/`.prefab` would be lost. An unrecognised value shows as `Missing/` rather than being silently cleared, and the drawer writes only on an actual change so viewing a component doesn't dirty its scene.

`EventRef` publisher overloads (extension methods) keep authored call sites from unwrapping the string.

### Name collisions

`[EventEnum(Prefix = "GuiEvents")]` resolves two same-named enums in different namespaces by renaming only the one that collides.

### Stage 2 — `EventId` as the identity

An interned one-based handle. Every per-event structure in the publisher — subscribers, sticky values, `Replay` journals — is keyed on it, and the name becomes `EventId.Name`: a projection, used for display and for the erased observer channel, never as the key.

Handler signatures are unchanged; a handler still receives `(string eventName, object sender, object data)` resolved off the id, which is what kept this from touching every subscriber downstream. `IEventIdPublisher` is deliberately kept *off* `IEventsPublisher<T>`, so no implementer breaks.

**On this stage's original claims** — it promised "no string hashing, no collisions, no allocation". Only the first held. Interning does not prevent collisions: identical names intern to the *same* id, which **is** the collision (`[EventEnum(Prefix)]` is the fix). Allocation was already zero, since names are pre-projected at facade construction. Stage 2's safety benefit had already been delivered by `EventsFor<T>` and `EventRef`; what it actually adds is the identity being a real value type and one less hash on the hot path. The ADR records this rather than the original claim.

### Stage 3 — typed payloads

`object data` was the larger hazard: a typo'd key fails loudly once Stage 0 lands, whereas a wrong payload cast fails *inside* a handler, where `Drain` catches it and logs an exception naming neither the expected type nor the publisher.

```csharp
[EventEnum]
public enum TempleRunEvents
{
    [EventPayload(typeof(PlayerFailedData))]
    [EventDelivery(EventDelivery.Sticky)]
    PlayerFailed,
}

private static readonly EventId<PlayerFailedData> Failed =
    EventsFor<TempleRunEvents>.Id<PlayerFailedData>(TempleRunEvents.PlayerFailed);

private void OnEnable()  => Failed.Subscribe(OnPlayerFailed);
private void Fail()      => Failed.Publish(this, new PlayerFailedData(...));

// No cast, and a wrong parameter type will not compile.
private void OnPlayerFailed(string eventName, object sender, PlayerFailedData data) { }
```

**What is and is not a compile error.** Once a call site holds an `EventId<TData>`, publishing the wrong payload and writing a handler with the wrong parameter type are both compile errors. The exception is the place the type argument is *written* — two call sites can write different type arguments for the same event, and no compiler can catch it, since each is internally consistent. That single point is checked at runtime against the attribute, first declaration wins, and a differing one is reported naming both types. Declared in a `static readonly` field, that check runs once at type initialization.

**The check that earns its keep** is on the untyped publishes a migrating project still has. Under `StrictMode` a payload that does not match the declaration is reported **at the publisher, naming the sender**; the wrapper around a typed handler also skips the handler and reports, but by then the sender is gone. Neither throws — a cast exception adds only a stack trace pointing at the handler, the one party not at fault.

**Erasure is preserved in both directions**, and is tested: a typed publish reaches untyped subscribers, an untyped publish reaches typed handlers, and `SubscribeToAllEvents` still receives `object`, so the global logger, `EventHistory` and the editor menus are unaffected. An event with no `[EventPayload]` stays unchecked — adoption is per event.

---

## Decisions reversed during implementation

Recorded in the ADR rather than quietly fixed, since each reverses something asserted earlier:

- **The Stage 0 collision detector never fired.** `_claimedPrefixes` was a static inside the generic `EventsPublisherEnums<T>` — and a static in a generic type exists *per constructed type*, so each closed type held only its own prefix. The cross-type comparison the check exists to make was exactly the one it could not see.
- **Replay timing reversed from end-of-frame to immediate.** End-of-frame *created* the gap `TryGetLast` then patched; a choice needing a second mechanism to compensate isn't carrying its weight.
- **Retention is top-frame only.** The ADR said a value "lives in the frame it was published into", overlooking that `PublishEvent` dispatches to *every* frame — so `Pop()` would have discarded nothing, making the `Replay` scoping story inoperative. Caught by a test.
- **Stage 1 — closing the write side — is unimplementable, and the goal was mis-stated.** A component whose event is chosen in the Inspector holds that name as *data, not a literal*, and still hands a string to the publisher at runtime — even after moving to `EventRef`. Seven components plus `EventMenu` would break permanently. The hazard was never the string API; it was a name typed by hand with nothing to check it, which is now closed at the authoring step.
- **`Type.FullName` rejected permanently.** It renames every event in the project to fix a local collision. `[EventEnum(Prefix = ...)]` supersedes it.
- **The `InnerException` claim didn't hold.** `DynamicInvoke` wraps throwing handlers, so the old code was fine on the ordinary path. The rewrite is a perf and logging win, not a bug fix.
- **Stage 2 delivered one of its three claims.** See above.

## Breaking change

`IEventsPublisher<T>` gains `RegisterEvent(T, EventDelivery)` and `TryGetLast`. Source-breaking for external implementers; there are none in `RunnerUGSTemplate` or `EventsPublishingTesting`. Stage 2's `IEventIdPublisher` and Stage 3's typed API add nothing to that interface.

## Tests

80 EditMode tests in `Tests/Editor`. Error expectations use `LogAssert`, so diagnostics are asserted rather than counted.

Mutation-checked rather than merely observed green. Retaining on every frame, firing sticky replay inline, dropping the null-name guard, ignoring the `Prefix` override, diverging the editor projection from the runtime one, zero-based `EventId` handles, clearing the intern table on reset, rebuilding a typed handler's wrapper at unsubscribe, and skipping either payload check each fail exactly the tests written for them.

Two mutations initially failed *nothing*, and both were treated as coverage gaps rather than written off:

- Removing the unset-`EventRef` guard changed no behaviour, because the publisher already rejects null names — the code comment was corrected rather than left asserting something no test supports.
- Accepting null for any payload type went unnoticed because no test sent null to a *value*-typed handler. Two tests were added; the mutation now fails three. It also surfaced that the null rule had two implementations that could drift, now consolidated into one.

Consumers must add the package to `testables` in `Packages/manifest.json` for Unity to build them.