### PR TITLE
Release 2.4.1: restore the re-entrant publish completion contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2026-08-15
+
+### Fixed
+
+- 2.4.0 changed when a publish made from *inside* a handler was delivered, while
+  documenting the change as no change. The nested publish was queued behind everything
+  already in flight instead of completing before the publishing statement returned, so a
+  handler that published event A and then acted on its results — or published A and then
+  C, with C's subscribers consuming what A's chain produced — ran against state that did
+  not exist yet. The deferral was also per-frame, so the same publish was deferred on the
+  frame whose drain was active and delivered inline on every other frame of the stack.
+  The 2.3.x contract is restored and now pinned by tests: `PublishEvent` returns only
+  after its event has been delivered, at any nesting depth. What the 2.4.0 rework
+  actually set out to do is kept — no reflection dispatch, and a callback that escapes
+  cannot strand queue entries for a later publish — and sticky replay triggered by a
+  `Subscribe` made mid-drain is untouched: it stays deferred, as decided when replay
+  became immediate. If you shipped on 2.4.0, see the erratum in
+  `Documentation~/UPGRADING.md` for how the reorder shows up.
+- The drain's error log could itself throw — it formats the handler's target and the
+  exception, either of which can have a throwing `ToString()` — which aborted the drain
+  and silently discarded every callback still queued. The logging is now contained, and
+  the queued callbacks are delivered.
+
+### Added
+
+- `NestedPublishOrderingTests` — five EditMode tests pinning the re-entrant publish
+  contract with control-flow assertions rather than final-sequence ones, bringing the
+  suite to 109. Four of the five fail on 2.4.0, which is how the regression was
+  demonstrated; all five pass on 2.3.1 and on this release.
+
 ## [2.4.0] - 2026-08-14
 
 Event identity and delivery timing. Everything here is additive: no public API was removed
@@ -60,6 +90,9 @@ wrong.
   removing a reflection dispatch and an `object[]` allocation per callback per publish.
 - A nested publish enqueues and returns rather than starting a second drain of the shared
   queue. Ordering is unchanged; the intent is now explicit rather than incidental.
+  *Correction: the second sentence was wrong. This deferred a nested publish's delivery
+  until after the publishing statement returned — and only on the frame whose drain was
+  active. Reversed in 2.4.1.*
 - Retention is top-frame only. Every publisher frame is still dispatched to, but only the
   frame that is top at publish time retains the value, so `Push`/`Pop` is a real scope.
 
@@ -99,5 +132,6 @@ wrong.
 
 - Initial package layout: assembly definitions, editor tooling, event subscriber logging.
 
+[2.4.1]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.4.1
 [2.4.0]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.4.0
 [2.3.1]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.3.1

--- a/Documentation~/UPGRADING.md
+++ b/Documentation~/UPGRADING.md
@@ -4,6 +4,12 @@ Nothing here is required. The package is source-compatible: a project that upgra
 changes nothing keeps working exactly as before, with better diagnostics. Every step
 below is opt-in and independently shippable.
 
+> **Skip 2.4.0 and upgrade to 2.4.1.** 2.4.0 accidentally changed when a publish made
+> from inside a handler was delivered, so the paragraph above was false for that one
+> release — see the [erratum](#erratum-240-reordered-re-entrant-publishes) at the end of
+> this file for who it affects and how it shows up. 2.4.1 restores the 2.3.x behaviour
+> and pins it with tests.
+
 The design reasoning is in `adr/0001-event-identity-and-delivery.md`. This file is the
 operational version — what to do, in what order, and which parts a tool can decide for
 you.
@@ -41,10 +47,9 @@ Add the package to `testables` in `Packages/manifest.json`:
 { "testables": [ "com.crawfissoftware.eventspublisher" ] }
 ```
 
-Unity only builds a package's tests when the consuming project opts in. 104 EditMode
-tests then appear under **Window > General > Test Runner**. They were verified on a stub
-harness rather than in a real editor, so running them once in a real project is a genuine
-check, not a formality.
+Unity only builds a package's tests when the consuming project opts in. 109 EditMode
+tests then appear under **Window > General > Test Runner**. Running them once in your
+project is a genuine check of the project's setup, not a formality.
 
 ### 2. Mark the event enums — `[EventEnum]`
 
@@ -224,3 +229,32 @@ in a project that still has raw-string publishes** — which most do, and will k
 release. Set it to `false` to disable recording entirely; it then costs one bool test per
 publish. `EventsDiagnostics.Reset()` clears what has been recorded, and is called
 automatically at the start of each play session so a report describes one run.
+
+## Erratum: 2.4.0 reordered re-entrant publishes
+
+2.4.0 shipped a behavioural change while documenting it as no change, so upgrades were
+not audited for it. A publish made from **inside** an event handler no longer completed
+before the publishing statement returned; it was queued and delivered after everything
+already in flight — including after the rest of the handler that published it. Top-level
+publishes were unaffected, which is why every test that existed at the time stayed green.
+2.4.1 restores the 2.3.x contract, now pinned by `NestedPublishOrderingTests`:
+`PublishEvent` returns only after its event has been delivered, at any nesting depth.
+
+If a project ran on 2.4.0, the thing to look back for is a silent reorder, not an error.
+Affected code publishes from inside a handler and relies on the effects of that publish
+afterwards:
+
+- a handler that publishes X and then reads state X's subscribers computed;
+- a handler that publishes two events in sequence, where the second event's subscribers
+  consume what the first event's chain produced;
+- auto-chain or bridge components that republish in response to events — the chained
+  event landed behind anything published later in the same cascade.
+
+It shows up as ordering casualties with nothing in the failure naming the event system: a
+guard like `if (cache.Count > 0)` or `if (_ready)` silently skipping because the event
+that satisfies it arrived late; a `NullReferenceException` in a handler whose input an
+earlier event should have set; state lagging one event behind what was just published.
+Moving to 2.4.1 removes the cause. To audit a run that stays on 2.4.0, search handlers
+for `PublishEvent` (and facade `Publish`) calls that are followed by more code in the
+same handler, or that are one of several publishes in one handler — those are the sites
+whose timing changed.

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -526,8 +526,10 @@ direction.
 1. **Re-entrancy into the drain.** `Subscribe` called from inside a handler — during
    an active publish drain — must not invoke a callback mid-drain. The replay is
    routed through the same `_callbackQueue`: if a drain is in progress it enqueues and
-   runs in order, otherwise it invokes immediately. The `_isDraining` guard added in
-   Stage 0 is the hook. **This is the part that needs care in implementation.**
+   runs in order, otherwise it invokes immediately. The drain guard added in Stage 0 is
+   the hook (originally an `_isDraining` bool; a depth counter since 2.4.1, so that a
+   nested *publish* drains re-entrantly while a mid-drain subscribe still defers).
+   **This is the part that needs care in implementation.**
 2. **Structural work in a handler.** A handler that loads or unloads scenes during the
    `Awake` of a still-loading scene is dicey in Unity. Such a subscriber defers itself
    (`StartCoroutine`, or a flag acted on in `Update`) — and would face the same
@@ -657,9 +659,24 @@ builds side by side. Claims below distinguish *fixed live defect* from *hardenin
 - **Nested publishes enqueue and return** rather than starting a second drain of the
   shared queue, with `try/finally` clearing the flag and the queue. Nested ordering
   was verified **identical to the previous behavior** (`A1,A2,B1,B2` and
-  `A1,A2,B1,B2,C1` for a two-level nest), so this is not a behavioral change — it
-  makes the intent stated in the existing comment explicit rather than incidental,
-  and guarantees a callback that escapes cannot strand entries for a later publish.
+  `A1,A2,B1,B2,C1` for a two-level nest), and this was recorded as not being a
+  behavioral change.
+  *Correction (2.4.1): it was a behavioral change, and those probes could not see it.*
+  Both observe a single chain of nested publishes as a final sequence, and the shared
+  FIFO queue yields the same sequence under either drain. What the old inline drain
+  additionally guaranteed was **completion**: every `PublishEvent`, at any depth,
+  drained the queue to empty before returning, so a handler could publish and then act
+  on the result — the contract auto-chained events are built on. Enqueue-and-return
+  broke exactly that (a handler publishing A and then C had C's subscribers run before
+  A's chain reached them), and because the guard was per-frame state, the same nested
+  publish was deferred on the frame whose drain was active while being delivered
+  inline on every other frame of the stack. It broke a consuming project silently —
+  the symptom was a guard skipping over a not-yet-filled cache, with nothing naming
+  the event system. 2.4.1 restored the completion contract with a re-entrant drain
+  behind a depth counter, kept this change's exception hygiene (an escaping callback
+  still cannot strand entries for a later publish), kept mid-drain subscribe replay
+  deferred, and pinned the contract in `NestedPublishOrderingTests` — probes that
+  assert on control flow, not just the final sequence.
 - **Null/empty event names are rejected** instead of reaching
   `Dictionary.ContainsKey(null)`, which throws `ArgumentNullException` (confirmed
   against the old build). Reachable via `FireEventAfterSceneLoads.OnDestroy`, which
@@ -694,10 +711,11 @@ consumers continue to compile.
 
 ### Tests
 
-`Tests/Editor` holds 104 EditMode tests across nine fixtures, covering dispatch ordering
-and isolation, the static facade and its registration timing, all three delivery
-policies, the interned identity, the Inspector catalog and `EventRef`, typed payloads,
-the late-delivery diagnostic, and the upgrade audit's reasoning. `Runtime/AssemblyInfo.cs` grants the test assembly access to internals so each
+`Tests/Editor` holds 109 EditMode tests across ten fixtures, covering dispatch ordering
+and isolation, the re-entrant publish completion contract, the static facade and its
+registration timing, all three delivery policies, the interned identity, the Inspector
+catalog and `EventRef`, typed payloads, the late-delivery diagnostic, and the upgrade
+audit's reasoning. `Runtime/AssemblyInfo.cs` grants the test assembly access to internals so each
 test can reset `EventsRegistry`'s static state — a public reset would be a footgun in
 game code.
 

--- a/Runtime/EventsPublisherInternal.cs
+++ b/Runtime/EventsPublisherInternal.cs
@@ -14,10 +14,12 @@ namespace CrawfisSoftware.Events
         private Queue<(string eventName, Action<string, object, object> callback, object sender, object data)> _callbackQueue
             = new Queue<(string eventName, Action<string, object, object> callback, object sender, object data)>();
 
-        // Guards against a callback that publishes an event, or subscribes to one, starting a second
-        // nested drain of the shared queue. Nested work enqueues and returns; the outermost drain
-        // processes it in order.
-        private bool _isDraining;
+        // Depth of re-entrant Drain calls. A publish made from inside a callback drains the shared
+        // queue itself, re-entrantly, so the published event is fully delivered before the publishing
+        // statement returns — the contract auto-chained events are built on. The depth is tracked so
+        // that a subscribe-triggered replay stays deferred while a drain is in flight, and so that only
+        // the outermost drain performs the escaped-exception cleanup in Drain's finally.
+        private int _drainDepth;
 
         // Retained values, per policy. These are per-frame by design: the policy registry is
         // stack-global, but what was actually published lives in the frame it was published into, so
@@ -108,7 +110,11 @@ namespace CrawfisSoftware.Events
                     EventsDiagnostics.NoteTransientSubscribe(eventId);
                     return;
             }
-            Drain();
+            // Unlike a nested publish, a replay stays deferred while a drain is in flight: it is
+            // delivered after the callbacks already queued, not inside the subscriber's Subscribe
+            // call. Decided when replay moved from end-of-frame to immediate, and pinned by
+            // SubscribeFromInsideAHandler_EnqueuesTheReplayRatherThanNesting.
+            if (_drainDepth == 0) Drain();
         }
 
         /// <summary>
@@ -247,14 +253,23 @@ namespace CrawfisSoftware.Events
         /// <summary>
         /// Invokes queued callbacks until the queue is empty.
         /// </summary>
-        /// <remarks>Nested work — a callback that publishes an event, or subscribes to one and
-        /// triggers a replay — only enqueues. The outermost call owns the drain, so the remaining
-        /// callbacks for the <em>current</em> event run first, as intended.</remarks>
+        /// <remarks>
+        /// <para>Two guarantees hold together here. Callbacks run in FIFO order off one shared queue,
+        /// so the remaining callbacks for the <em>current</em> event run before any newly published
+        /// event's callbacks. And a publish drains re-entrantly, so by the time <c>PublishEvent</c>
+        /// returns — at any nesting depth — everything it enqueued has been delivered. Auto-chained
+        /// events depend on the second guarantee: a producer that publishes an event whose subscribers
+        /// derive state, then publishes a second event whose subscribers consume that state, needs the
+        /// first chain complete before the second publish is made.</para>
+        /// <para>A consequence of holding both at once: a nested publish also flushes the current
+        /// event's still-queued callbacks, since they sit ahead of the nested event's in the queue.
+        /// They could not run any later without breaking one of the two guarantees.</para>
+        /// <para>Subscribe-triggered replay is the one caller that stays deferred while a drain is in
+        /// flight — see <see cref="ReplayTo"/>.</para>
+        /// </remarks>
         private void Drain()
         {
-            if (_isDraining) return;
-
-            _isDraining = true;
+            _drainDepth++;
             try
             {
                 while (_callbackQueue.Count > 0)
@@ -267,16 +282,32 @@ namespace CrawfisSoftware.Events
                     }
                     catch (Exception e)
                     {
-                        UnityEngine.Debug.LogError(
-                            $"Exception publishing {message.eventName} to {callback.Target}: {e}");
+                        try
+                        {
+                            UnityEngine.Debug.LogError(
+                                $"Exception publishing {message.eventName} to {callback.Target}: {e}");
+                        }
+                        catch (Exception loggingFailure)
+                        {
+                            // Formatting the message runs ToString on the handler's target and on the
+                            // exception, either of which can itself throw. A log line must never abort
+                            // the drain and discard the callbacks still queued.
+                            UnityEngine.Debug.LogError(
+                                $"Exception publishing {message.eventName}; the details could not be formatted " +
+                                $"({loggingFailure.GetType().Name} thrown while logging {e.GetType().Name}).");
+                        }
                     }
                 }
             }
             finally
             {
-                // Never leave stale callbacks queued; they would otherwise flush during an unrelated publish.
-                _callbackQueue.Clear();
-                _isDraining = false;
+                _drainDepth--;
+                // Nothing pends here on any non-fatal path: the loop runs to empty, handler exceptions
+                // are contained above, and an exception escaping a nested drain is caught by the level
+                // that invoked the publishing handler. If a process-level exception still escapes the
+                // outermost drain, discard rather than leave entries to flush during an unrelated
+                // later publish.
+                if (_drainDepth == 0) _callbackQueue.Clear();
             }
         }
 

--- a/Tests/Editor/EventsPublisherTests.cs
+++ b/Tests/Editor/EventsPublisherTests.cs
@@ -29,7 +29,7 @@ namespace CrawfisSoftware.Events.Tests
         }
 
         [Test]
-        public void NestedPublish_TwoLevelsDeep_StaysBreadthFirst()
+        public void NestedPublish_TwoLevelsDeep_DeliversLevelByLevel()
         {
             Bus.RegisterEvent("A");
             Bus.RegisterEvent("B");
@@ -41,6 +41,9 @@ namespace CrawfisSoftware.Events.Tests
 
             Bus.PublishEvent("A", null, null);
 
+            // The FIFO sequence, identical under the re-entrant completion drain: A2 is queued ahead
+            // of B1, and C1 is enqueued mid-chain by B1. When control returns to each publisher is a
+            // separate contract, pinned by NestedPublishOrderingTests.
             Assert.AreEqual("A1,A2,B1,C1", string.Join(",", Log));
         }
 

--- a/Tests/Editor/NestedPublishOrderingTests.cs
+++ b/Tests/Editor/NestedPublishOrderingTests.cs
@@ -1,0 +1,123 @@
+using NUnit.Framework;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    /// <summary>
+    /// The re-entrant publish contract: <c>PublishEvent</c> returns only after its event has been
+    /// delivered to every subscriber, however deep the publish is nested.
+    /// </summary>
+    /// <remarks>
+    /// <para>Auto-chained architectures publish from inside handlers constantly, and producers build
+    /// state across consecutive publishes: publish one event whose subscribers derive state, then
+    /// publish a second whose subscribers consume it. That pattern is only sound if a nested publish
+    /// has completed by the time the publishing statement returns, which is what this fixture pins.</para>
+    /// <para>The pre-2.4.0 drain gave exactly that guarantee, as an emergent property of draining the
+    /// shared FIFO queue inline: whoever called <c>PublishEvent</c> got the queue drained to empty
+    /// before it returned. 2.4.0 replaced the inline drain with enqueue-and-return under an
+    /// <c>_isDraining</c> guard and recorded the ordering as unchanged — but the probes used to verify
+    /// that (a single chain of nested publishes, observed only as a final sequence) produce identical
+    /// sequences under both contracts. A handler that publishes twice, or does anything after its
+    /// publish statement, can tell them apart; these tests do.</para>
+    /// </remarks>
+    public class NestedPublishOrderingTests : EventsTestBase
+    {
+        [Test]
+        public void TopLevelPublish_IsDeliveredBeforeItReturns()
+        {
+            Bus.SubscribeToEvent("A", Recorder("A1"));
+
+            Bus.PublishEvent("A", null, null);
+            Log.Add("returned");
+
+            Assert.AreEqual("A1:-,returned", string.Join(",", Log));
+        }
+
+        [Test]
+        public void NestedPublish_IsDeliveredBeforeItReturns()
+        {
+            Bus.SubscribeToEvent("B", Recorder("B1"));
+            Bus.SubscribeToEvent("Start", (e, s, d) =>
+            {
+                Bus.PublishEvent("B", null, null);
+                // Anything the publisher does after this statement — cache a result, publish a
+                // dependent event, tear something down — assumes B's subscribers have already run.
+                Log.Add("after-B");
+            });
+
+            Bus.PublishEvent("Start", null, null);
+
+            Assert.AreEqual("B1:-,after-B", string.Join(",", Log),
+                "a publish made from inside a handler must complete before the publishing statement returns");
+        }
+
+        [Test]
+        public void HandlerPublishingTwoEvents_DeliversTheFirstEventsChainBeforeTheSecondEvent()
+        {
+            // The auto-chain shape that broke a consumer on 2.4.0: A's handler responds by publishing
+            // B (segment created -> geometry ready, cached by a third component), and C's subscribers
+            // consume what B's subscribers cached (active track changing -> pop the cache). Deliver C
+            // before B and the cache is silently empty at the moment it is read.
+            Bus.SubscribeToEvent("A", (e, s, d) => Bus.PublishEvent("B", null, null));
+            Bus.SubscribeToEvent("B", Recorder("B"));
+            Bus.SubscribeToEvent("C", Recorder("C"));
+            Bus.SubscribeToEvent("Start", (e, s, d) =>
+            {
+                Bus.PublishEvent("A", null, null);
+                Bus.PublishEvent("C", null, null);
+            });
+
+            Bus.PublishEvent("Start", null, null);
+
+            Assert.AreEqual("B:-,C:-", string.Join(",", Log),
+                "everything the publish of A caused must be delivered before the later publish of C");
+        }
+
+        [Test]
+        public void NestedPublish_FlushesTheCurrentEventsRemainingHandlersBeforeReturning()
+        {
+            // Forced by two invariants held together: the current event's remaining handlers run
+            // before the nested event's handlers (the shared FIFO queue), and the nested publish
+            // completes before returning (this fixture). A2 therefore runs inside A1's publish call,
+            // ahead of B1 — it cannot run any later without one of the two invariants breaking.
+            Bus.SubscribeToEvent("A", (e, s, d) =>
+            {
+                Log.Add("A1");
+                Bus.PublishEvent("B", null, null);
+                Log.Add("A1-after-B");
+            });
+            Bus.SubscribeToEvent("A", (e, s, d) => Log.Add("A2"));
+            Bus.SubscribeToEvent("B", (e, s, d) => Log.Add("B1"));
+
+            Bus.PublishEvent("A", null, null);
+
+            Assert.AreEqual("A1,A2,B1,A1-after-B", string.Join(",", Log));
+        }
+
+        [Test]
+        public void NestedPublish_BehavesTheSameOnEveryFrameOfTheStack()
+        {
+            // The 2.4.0 deferral was per-frame state, so a nested publish was deferred on the frame
+            // whose drain was active while being delivered inline on every other frame — one publish,
+            // two orderings. The contract must not depend on which frame a subscriber sits on.
+            Bus.SubscribeToEvent("B", Recorder("B-lower"));
+            Bus.Push();
+            try
+            {
+                Bus.SubscribeToEvent("A", (e, s, d) =>
+                {
+                    Bus.PublishEvent("B", null, "x");
+                    Log.Add("A-done");
+                });
+                Bus.SubscribeToEvent("B", Recorder("B-top"));
+
+                Bus.PublishEvent("A", null, null);
+            }
+            finally
+            {
+                Bus.Pop();
+            }
+
+            Assert.AreEqual("B-top:x,B-lower:x,A-done", string.Join(",", Log));
+        }
+    }
+}

--- a/Tests/Editor/NestedPublishOrderingTests.cs.meta
+++ b/Tests/Editor/NestedPublishOrderingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c3f2a91d5e84b06a1c9f47d20b6e8aa

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.crawfissoftware.eventspublisher",
   "displayName": "Events Publisher",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "unity": "2022.3",
   "description": "Lightweight, allocation-safe event/messaging publisher for Unity projects. Editor tooling included.",
   "keywords": [ "events", "messaging", "publisher", "observer", "csharp", "unity" ],


### PR DESCRIPTION
## What broke

2.4.0 replaced `PublishEvent`'s inline drain with enqueue-and-return behind a per-frame `_isDraining` guard, and recorded the ordering as unchanged (CHANGELOG: "Ordering is unchanged"; ADR: "verified identical to the previous behavior"). The verification probes observed a single nested chain as a final sequence, which the shared FIFO queue keeps identical under either drain. What they could not see is **completion**: before 2.4.0, every `PublishEvent` — at any depth — drained the queue to empty before returning, so a handler could publish and then act on the result.

Enqueue-and-return broke exactly that:

- A handler publishing A and then C had C's subscribers run **before** A's chain reached them (`["C","B"]` instead of `["B","C"]` in the minimal repro).
- Because the guard was per-frame state, the same nested publish was deferred on the frame whose drain was active while being **delivered inline** on every other frame of the stack — one publish, two orderings.

This silently broke a consuming project's auto-chain: a producer published `TrackSegmentCreated` (whose subscriber chains `SegmentGeometryReady`, cached by a third component) and later `ActiveTrackChanging` (which pops that cache). Under 2.4.0 the cache was still empty; a `count > 0` guard skipped, a struct field stayed default, and a later handler threw NRE with nothing pointing at the event system.

## The fix

- `_isDraining` (bool) becomes `_drainDepth` (int), and `Drain()` is re-entrant: a nested publish drains the shared queue itself, so the published event is fully delivered before the publishing statement returns. FIFO is untouched, so the current event's remaining handlers still run ahead of the nested event's.
- `ReplayTo` drains only at depth zero — the recorded 2.4.0 decision that a `Subscribe` made mid-drain enqueues its replay rather than nesting is preserved, and its pinning test passes unchanged.
- The drain's catch contains its own logging: formatting the error message runs `ToString` on the handler's target and on the exception, either of which can throw. That escape used to abort the drain and silently discard every queued callback (and pre-2.4.0 it *stranded* them, flushing stale into the next unrelated publish). The depth-zero `finally` still clears as a last resort, now confined to process-level failures.

## Verification (real editor, Unity 6000.4.3f1 EditMode, via EventsPublishingTesting)

| Runtime | Result |
|---|---|
| deff6ae (2.3.1) | 5/5 new ordering pins pass |
| Pristine 2.4.0 | 105/109 — the only failures are 4 of the 5 new pins; all 104 pre-existing tests pass |
| This branch | **109/109** |

Also A/B'd on a UnityEngine-stub harness (the ADR's own verification technique), including a probe showing the ADR's two original sequences are byte-identical under both contracts — which is how the regression passed verification — and the two-frame probe demonstrating 2.4.0's frame-dependent ordering.

## Also in this change

- `NestedPublishOrderingTests` — five tests pinning the contract with control-flow assertions rather than final-sequence ones (completion at top level and nested, two publishes from one handler, the sibling flush inside a nested publish, same behavior on every stack frame).
- `NestedPublish_TwoLevelsDeep_StaysBreadthFirst` → `_DeliversLevelByLevel`: the sequence it asserts cannot distinguish the two contracts, so the old name recorded a conclusion the test cannot support.
- CHANGELOG: in-place correction under 2.4.0's "Ordering is unchanged" bullet, plus the 2.4.1 entry.
- ADR 0001: the "not a behavioral change" consequence corrected in the ADR's own style, recording why the probes were blind.
- UPGRADING: "skip 2.4.0" callout up top and an erratum describing who 2.4.0 affects and how the silent reorder shows up, since there is no stack trace to grep for.
- `package.json` → 2.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BR5s8JKtvRhzawu4urmt5d