### PR TITLE
Release 2.5.0: enumerate the registered event domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-08-27
+
+Additive: nothing was removed or changed, so a 2.4.x consumer that upgrades and changes nothing
+keeps working.
+
+### Added
+
+- `EventsRegistry.RegisteredEnumTypes` — every enum family the registry currently holds, as a
+  read-only collection. The registry could already report an event's policy, its payload type, and
+  the prefix a given enum projects onto, but not *which* enums had registered, so anything wanting
+  to describe a project's event domains had to run a reflection sweep of its own and hope it agreed
+  with the runtime. Every read hands back the same collection rather than building a snapshot. Both
+  sides of a prefix collision are listed: both families registered, and seeing them share a prefix
+  is the point.
+- **CrawfisSoftware > Events > List Domains** — one console line per registered domain, giving the
+  prefix, the enum's full name, how many members it declares, and how many of those declare
+  `[EventPayload]`, `Sticky` or `Replay`. Nothing sweeps in edit mode — the `BeforeSceneLoad` sweep
+  runs before the first scene loads — so the menu runs that same sweep before reporting rather than
+  walking the assemblies a second, drifting way. In play mode it additionally lists the families that
+  registered lazily, which no attribute-based scan can see.
+- 13 EditMode tests covering the enumeration and the domain summary, bringing the suite to 122.
+
 ## [2.4.1] - 2026-08-15
 
 ### Fixed
@@ -132,6 +154,7 @@ wrong.
 
 - Initial package layout: assembly definitions, editor tooling, event subscriber logging.
 
+[2.5.0]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.5.0
 [2.4.1]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.4.1
 [2.4.0]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.4.0
 [2.3.1]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.3.1

--- a/Editor/EventDomainCatalog.cs
+++ b/Editor/EventDomainCatalog.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace CrawfisSoftware.Events.Editor
+{
+    /// <summary>
+    /// One registered event-enum family, summarised for display.
+    /// </summary>
+    /// <remarks>The counts are of declared members, which is what the enum's source shows. Members
+    /// sharing a value are one event rather than two — the projection keys on the value, so an alias
+    /// never becomes a second event name — so a family that uses aliases publishes fewer events than it
+    /// declares members, and the attribute counts include an alias's <see cref="EventDeliveryAttribute"/>
+    /// or <see cref="EventPayloadAttribute"/>, which the registry never reads: it resolves the value
+    /// back to one member, the first one declared with it.</remarks>
+    internal readonly struct EventDomain
+    {
+        /// <summary>The prefix every event in the family is named under, without its trailing slash.</summary>
+        internal readonly string Prefix;
+
+        /// <summary>The enum type itself.</summary>
+        internal readonly Type EnumType;
+
+        /// <summary>How many members the enum declares.</summary>
+        internal readonly int MemberCount;
+
+        /// <summary>How many of them declare an <see cref="EventPayloadAttribute"/>.</summary>
+        internal readonly int PayloadCount;
+
+        /// <summary>How many of them are declared <see cref="EventDelivery.Sticky"/>.</summary>
+        internal readonly int StickyCount;
+
+        /// <summary>How many of them are declared <see cref="EventDelivery.Replay"/>.</summary>
+        internal readonly int ReplayCount;
+
+        internal EventDomain(string prefix, Type enumType, int memberCount, int payloadCount,
+                             int stickyCount, int replayCount)
+        {
+            Prefix = prefix;
+            EnumType = enumType;
+            MemberCount = memberCount;
+            PayloadCount = payloadCount;
+            StickyCount = stickyCount;
+            ReplayCount = replayCount;
+        }
+    }
+
+    /// <summary>
+    /// Summarises the event-enum families the registry holds, for the <c>List Domains</c> menu.
+    /// </summary>
+    /// <remarks>
+    /// <para>The families are handed in from <see cref="EventsRegistry.RegisteredEnumTypes"/> rather
+    /// than discovered here, so what is listed is what the publisher is keyed on. A reflection walk of
+    /// this tool's own would be a second definition of "an event family" and could disagree with the
+    /// runtime one — the same drift <see cref="EventNameCatalog"/> exists to prevent on the projection,
+    /// and a listing that quietly disagrees with the registry is worse than no listing.</para>
+    /// <para>Free of editor APIs, so it can be tested directly.</para>
+    /// </remarks>
+    internal static class EventDomainCatalog
+    {
+        /// <summary>
+        /// Summarises each enum family, ordered for display.
+        /// </summary>
+        /// <remarks>Ordered by prefix, then by full type name so that two families colliding on one
+        /// prefix still list deterministically — and adjacently, which is what makes the collision
+        /// legible here as well as in the error the registry logs for it.</remarks>
+        internal static List<EventDomain> Describe(IEnumerable<Type> enumTypes)
+        {
+            var domains = new List<EventDomain>();
+            if (enumTypes == null) return domains;
+
+            foreach (Type enumType in enumTypes)
+            {
+                if (enumType == null || !enumType.IsEnum) continue;
+
+                int members = 0, payloads = 0, sticky = 0, replay = 0;
+                foreach (FieldInfo member in enumType.GetFields(BindingFlags.Public | BindingFlags.Static))
+                {
+                    members++;
+                    if (member.IsDefined(typeof(EventPayloadAttribute), false)) payloads++;
+
+                    var delivery = (EventDeliveryAttribute)Attribute.GetCustomAttribute(
+                        member, typeof(EventDeliveryAttribute));
+                    if (delivery == null) continue;
+                    if (delivery.Delivery == EventDelivery.Sticky) sticky++;
+                    else if (delivery.Delivery == EventDelivery.Replay) replay++;
+                }
+
+                domains.Add(new EventDomain(
+                    EventsRegistry.GetPrefix(enumType), enumType, members, payloads, sticky, replay));
+            }
+
+            domains.Sort(CompareForDisplay);
+            return domains;
+        }
+
+        private static int CompareForDisplay(EventDomain a, EventDomain b)
+        {
+            int byPrefix = string.CompareOrdinal(a.Prefix, b.Prefix);
+            return byPrefix != 0 ? byPrefix : string.CompareOrdinal(a.EnumType.FullName, b.EnumType.FullName);
+        }
+
+        /// <summary>Renders one domain as a single line.</summary>
+        /// <remarks>The prefix is shown with its slash, because that is the shape of the names the
+        /// family publishes; the type is named in full, because the prefix is projected from the simple
+        /// name and two families in different namespaces can share it.</remarks>
+        internal static string Format(EventDomain domain)
+        {
+            return $"{domain.Prefix}/  —  {domain.EnumType.FullName}  —  {domain.MemberCount} member(s), " +
+                   $"{domain.PayloadCount} with [EventPayload], {domain.StickyCount} Sticky, " +
+                   $"{domain.ReplayCount} Replay";
+        }
+    }
+}

--- a/Editor/EventDomainCatalog.cs.meta
+++ b/Editor/EventDomainCatalog.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: af7eafa76d0aef7d84cce6447ec95488

--- a/Editor/EventDomainsMenu.cs
+++ b/Editor/EventDomainsMenu.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+using UnityEditor;
+
+using UnityEngine;
+
+namespace CrawfisSoftware.Events.Editor
+{
+    /// <summary>
+    /// Lists the event-enum families the registry holds, one console line each.
+    /// </summary>
+    /// <remarks>
+    /// <para>Nothing sweeps in edit mode — the
+    /// <see cref="UnityEngine.RuntimeInitializeLoadType.BeforeSceneLoad"/> sweep runs before the first
+    /// scene loads — so a listing taken straight from the registry would report that a project with a
+    /// dozen event families has none. This runs that same sweep first rather than walking the
+    /// assemblies its own way: the registration it performs in the editor is the registration play
+    /// mode performs, it subscribes to nothing and publishes nothing, and entering play mode resets
+    /// the static state and sweeps again — so nothing it registers here can outlive the editor session
+    /// or reach a build.</para>
+    /// <para>The sweep is idempotent, so the menu behaves the same in play mode, where it reports the
+    /// lazily-registered families too: an enum with no <see cref="EventEnumAttribute"/> registers the
+    /// first time its <see cref="EventsFor{T}"/> is touched, and is a domain from that moment on.</para>
+    /// <para>Console rather than a window, matching <c>List Current Subscribers</c>. One line per
+    /// domain is readable in the console list without opening anything, and the lines survive being
+    /// copied out.</para>
+    /// </remarks>
+    internal static class EventDomainsMenu
+    {
+        private const string MENU_LOCATION = "CrawfisSoftware/Events/List Domains";
+
+        [MenuItem(MENU_LOCATION)]
+        private static void ListDomains()
+        {
+            EventsRegistry.RegisterAnnotatedEventEnums();
+
+            List<EventDomain> domains = EventDomainCatalog.Describe(EventsRegistry.RegisteredEnumTypes);
+            if (domains.Count == 0)
+            {
+                Debug.Log("No event domains are registered. Mark an event enum with [EventEnum] to " +
+                          "register it before any scene loads.");
+                return;
+            }
+
+            Debug.Log($"Listing {domains.Count} registered event domain(s) ...");
+            foreach (EventDomain domain in domains)
+            {
+                Debug.Log(EventDomainCatalog.Format(domain));
+            }
+        }
+    }
+}

--- a/Editor/EventDomainsMenu.cs.meta
+++ b/Editor/EventDomainsMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3e1edb8caf2e9bf17e336a10287ce629

--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ public enum Events { ... }
 Only that enum's names change. Set it when the enum is introduced — changing it later
 renames every one of its events and breaks any name already serialized.
 
+## Listing the event domains
+
+**CrawfisSoftware > Events > List Domains** logs one line per registered enum family: the
+prefix it publishes under, the enum's full name, how many members it declares, and how
+many of those declare `[EventPayload]`, `Sticky` or `Replay`.
+
+```
+GameFlowEvents/  —  MyGame.Flow.GameFlowEvents  —  7 member(s), 2 with [EventPayload], 3 Sticky, 0 Replay
+```
+
+Nothing sweeps in edit mode — the sweep runs before the first scene loads — so the menu
+runs that same sweep before reporting. In play mode it also lists the families that
+registered lazily on first touch, which no scan for `[EventEnum]` can see.
+
+The same list is available in code as `EventsRegistry.RegisteredEnumTypes`, with
+`EventsRegistry.GetPrefix(type)` for the prefix each one projects onto. It reports what
+the registry holds rather than what the project contains, and every read hands back the
+same collection rather than building a snapshot.
+
 ## Diagnostics
 
 `EventsPublisher.StrictMode` — on by default in the editor and development builds —

--- a/Runtime/AssemblyInfo.cs
+++ b/Runtime/AssemblyInfo.cs
@@ -4,3 +4,9 @@ using System.Runtime.CompilerServices;
 // from clean static state, and EventsPublisherInternal's registration probe. Neither belongs on the
 // public API — a public "reset everything" would be a footgun in game code.
 [assembly: InternalsVisibleTo("CrawfisSoftware.EventsPublisher.Tests")]
+
+// The editor's "List Domains" menu re-runs the before-scene-load sweep on demand, because outside play
+// mode it has not run and the registry it reports on would be empty. Calling the same sweep the runtime
+// calls is what keeps the menu describing the registry rather than a second reflection walk that could
+// disagree with it. The sweep stays off the public API for the same reason the reset does.
+[assembly: InternalsVisibleTo("CrawfisSoftware.EventsPublisher.Editor")]

--- a/Runtime/EventsRegistry.cs
+++ b/Runtime/EventsRegistry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Reflection;
 
 using UnityEngine;
@@ -19,6 +20,15 @@ namespace CrawfisSoftware.Events
     {
         // Which enum type has claimed a given "TypeName/" prefix, across all enum families.
         private static readonly Dictionary<string, Type> _claimedPrefixes = new Dictionary<string, Type>();
+
+        // Every enum type that has registered, in registration order. Kept alongside _claimedPrefixes
+        // rather than read out of it: on a collision only the first claimant is recorded there, and both
+        // families did register. A list because the count is the number of event families in a project —
+        // a handful — and the read-only wrapper is built once, so reading the property hands back the
+        // same collection rather than building a snapshot per call.
+        private static readonly List<Type> _registeredEnums = new List<Type>();
+        private static readonly ReadOnlyCollection<Type> _registeredEnumsView =
+            new ReadOnlyCollection<Type>(_registeredEnums);
 
         // Reset callbacks published by each EventsFor<T> that has been initialized.
         private static readonly List<Action> _resetHandlers = new List<Action>();
@@ -210,6 +220,11 @@ namespace CrawfisSoftware.Events
         internal static void ClaimPrefix(string prefix, Type enumType)
         {
             if (string.IsNullOrEmpty(prefix) || enumType == null) return;
+
+            // Recorded before the collision check, so that both sides of a collision are listed as the
+            // registered families they both are. Linear, and deliberately so: this runs once per family.
+            if (!_registeredEnums.Contains(enumType)) _registeredEnums.Add(enumType);
+
             if (_claimedPrefixes.TryGetValue(prefix, out Type existing))
             {
                 if (existing != enumType)
@@ -222,6 +237,28 @@ namespace CrawfisSoftware.Events
             }
             _claimedPrefixes[prefix] = enumType;
         }
+
+        /// <summary>
+        /// Every enum type registered as an event family, in the order the families registered.
+        /// </summary>
+        /// <remarks>
+        /// <para>This is what the registry holds, not what the project contains. A family marked
+        /// <see cref="EventEnumAttribute"/> is here from the
+        /// <see cref="RuntimeInitializeLoadType.BeforeSceneLoad"/> sweep onwards; an unmarked one appears
+        /// the moment its <see cref="EventsFor{T}"/> is first touched, and not before. Nothing sweeps in
+        /// edit mode, so an editor tool that wants the marked families must ask for them — which is what
+        /// the <c>CrawfisSoftware &gt; Events &gt; List Domains</c> menu item does.</para>
+        /// <para>The prefix a listed type projects onto is <see cref="GetPrefix"/>. Two of them can
+        /// report the same one: that is a collision, it is reported as an error when it happens, and
+        /// both families are listed here because both of them registered.</para>
+        /// <para>Read-only through this reference and live behind it: every read hands back the same
+        /// collection rather than a snapshot, so a family registering later appears without this being
+        /// read again. Take a copy before walking it if the walk itself can register a family — which
+        /// means constructing an <see cref="EventsFor{T}"/> — since that invalidates an enumerator in
+        /// progress. Like the rest of the registry it assumes the Unity main thread; nothing here is
+        /// synchronized.</para>
+        /// </remarks>
+        public static IReadOnlyCollection<Type> RegisteredEnumTypes => _registeredEnumsView;
 
         /// <summary>
         /// Registers a callback that drops a generic facade's cached state, so it is rebuilt on next use.
@@ -256,6 +293,9 @@ namespace CrawfisSoftware.Events
             }
             _resetHandlers.Clear();
             _claimedPrefixes.Clear();
+            // Cleared with the prefixes it was recorded alongside: the facades are gone, so reporting
+            // their families as registered would describe a registry that no longer exists.
+            _registeredEnums.Clear();
             _policies.Clear();
             _payloadTypes.Clear();
             TypedSubscriptions.Clear();

--- a/Tests/Editor/EventDomainsTests.cs
+++ b/Tests/Editor/EventDomainsTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using CrawfisSoftware.Events.Editor;
+
+using NUnit.Framework;
+
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    [EventEnum]
+    public enum DomainListingTestEvents
+    {
+        [EventPayload(typeof(string))]
+        [EventDelivery(EventDelivery.Sticky)]
+        ConfigLoaded,
+
+        Jumped,
+
+        [EventDelivery(EventDelivery.Replay)]
+        SegmentCreated,
+    }
+
+    [EventEnum(Prefix = "DomainListingPrefixed")]
+    public enum DomainPrefixOverrideTestEvents { Alpha, Beta }
+
+    /// <summary>Unmarked on purpose: it registers on first touch, not in the sweep.</summary>
+    public enum DomainUnmarkedTestEvents { Only }
+
+    namespace DomainCollidingA { public enum DomainCollisionEvents { Alpha } }
+    namespace DomainCollidingB { public enum DomainCollisionEvents { Alpha } }
+
+    /// <summary>
+    /// Enumerating the registered domains, and the summary the <c>List Domains</c> menu prints from it.
+    /// </summary>
+    public class EventDomainsTests : EventsTestBase
+    {
+        private static EventDomain Describe(Type enumType)
+        {
+            List<EventDomain> domains = EventDomainCatalog.Describe(new[] { enumType });
+            Assert.AreEqual(1, domains.Count);
+            return domains[0];
+        }
+
+        private static EventDomain Find(IEnumerable<EventDomain> domains, Type enumType)
+        {
+            foreach (EventDomain domain in domains)
+                if (domain.EnumType == enumType) return domain;
+            throw new AssertionException("no domain reported for " + enumType.FullName);
+        }
+
+        private static int CountOf(Type enumType)
+        {
+            int count = 0;
+            foreach (Type registered in EventsRegistry.RegisteredEnumTypes)
+                if (registered == enumType) count++;
+            return count;
+        }
+
+        [Test]
+        public void MarkedFamily_IsListedOnceTheSweepHasRun()
+        {
+            // The enumeration reports what has registered, not what the project contains — which is why
+            // the menu sweeps before reading it rather than assuming something already has.
+            CollectionAssert.DoesNotContain(EventsRegistry.RegisteredEnumTypes, typeof(DomainListingTestEvents));
+
+            EventsRegistry.RegisterAnnotatedEventEnums();
+
+            CollectionAssert.Contains(EventsRegistry.RegisteredEnumTypes, typeof(DomainListingTestEvents));
+        }
+
+        [Test]
+        public void UnmarkedFamily_IsListedFromItsFirstTouch()
+        {
+            // [EventEnum] governs when a family registers, not whether it counts as a domain: an unmarked
+            // one is a domain from the moment its facade is built, and the listing must say so.
+            EventsRegistry.RegisterAnnotatedEventEnums();
+            CollectionAssert.DoesNotContain(EventsRegistry.RegisteredEnumTypes, typeof(DomainUnmarkedTestEvents));
+
+            EventsFor<DomainUnmarkedTestEvents>.EnsureRegistered();
+
+            CollectionAssert.Contains(EventsRegistry.RegisteredEnumTypes, typeof(DomainUnmarkedTestEvents));
+        }
+
+        [Test]
+        public void ReRegisteringTheSameFamily_ListsItOnce()
+        {
+            // Must stay idempotent: statics survive a domain reload when the project disables it, and a
+            // family listed twice would read as two domains sharing a prefix, which is the error case.
+            EventsFor<DomainUnmarkedTestEvents>.EnsureRegistered();
+            EventsRegistry.ClaimPrefix("DomainUnmarkedTestEvents", typeof(DomainUnmarkedTestEvents));
+
+            Assert.AreEqual(1, CountOf(typeof(DomainUnmarkedTestEvents)));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void CollidingFamilies_AreBothListed()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("both project onto the event name prefix 'DomainCollisionEvents/'"));
+
+            EventsFor<DomainCollidingA.DomainCollisionEvents>.EnsureRegistered();
+            EventsFor<DomainCollidingB.DomainCollisionEvents>.EnsureRegistered();
+
+            // Only the first claimant holds the prefix, but both families registered and both publish
+            // under it. Listing only the winner would hide the half of the collision that is surprising.
+            CollectionAssert.Contains(EventsRegistry.RegisteredEnumTypes, typeof(DomainCollidingA.DomainCollisionEvents));
+            CollectionAssert.Contains(EventsRegistry.RegisteredEnumTypes, typeof(DomainCollidingB.DomainCollisionEvents));
+        }
+
+        [Test]
+        public void Reset_EmptiesTheEnumeration()
+        {
+            EventsFor<DomainUnmarkedTestEvents>.EnsureRegistered();
+            Assert.Greater(EventsRegistry.RegisteredEnumTypes.Count, 0);
+
+            EventsRegistry.ResetStaticState();
+
+            Assert.AreEqual(0, EventsRegistry.RegisteredEnumTypes.Count);
+        }
+
+        [Test]
+        public void Enumeration_IsTheSameCollectionEachRead()
+        {
+            EventsFor<DomainUnmarkedTestEvents>.EnsureRegistered();
+
+            // The same collection every read, rather than a fresh snapshot per call.
+            Assert.AreSame(EventsRegistry.RegisteredEnumTypes, EventsRegistry.RegisteredEnumTypes);
+            CollectionAssert.AreEqual(new List<Type>(EventsRegistry.RegisteredEnumTypes),
+                                      new List<Type>(EventsRegistry.RegisteredEnumTypes));
+        }
+
+        [Test]
+        public void Enumeration_CannotBeMutatedThroughItsReference()
+        {
+            var asList = EventsRegistry.RegisteredEnumTypes as IList<Type>;
+
+            Assert.IsNotNull(asList, "the enumeration is expected to be a read-only view, not a bare list");
+            Assert.Throws<NotSupportedException>(() => asList.Add(typeof(DomainUnmarkedTestEvents)));
+            Assert.AreEqual(0, EventsRegistry.RegisteredEnumTypes.Count);
+        }
+
+        [Test]
+        public void PrefixOverride_IsWhatTheDomainReports()
+        {
+            EventDomain domain = Describe(typeof(DomainPrefixOverrideTestEvents));
+
+            Assert.AreEqual("DomainListingPrefixed", domain.Prefix);
+            // Pinned against the runtime projection: a reported prefix that is not the one the family
+            // publishes under would send someone looking for events under a name nothing is keyed on.
+            Assert.AreEqual(EventsFor<DomainPrefixOverrideTestEvents>.GetEventName(DomainPrefixOverrideTestEvents.Alpha),
+                            domain.Prefix + "/" + DomainPrefixOverrideTestEvents.Alpha);
+        }
+
+        [Test]
+        public void Describe_CountsMembersPayloadsAndRetainingPolicies()
+        {
+            EventDomain domain = Describe(typeof(DomainListingTestEvents));
+
+            Assert.AreEqual(3, domain.MemberCount);
+            Assert.AreEqual(1, domain.PayloadCount);
+            Assert.AreEqual(1, domain.StickyCount);
+            Assert.AreEqual(1, domain.ReplayCount);
+        }
+
+        [Test]
+        public void Describe_IgnoresNullsAndNonEnums()
+        {
+            Assert.AreEqual(0, EventDomainCatalog.Describe(null).Count);
+            Assert.AreEqual(0, EventDomainCatalog.Describe(new Type[] { null, typeof(string) }).Count);
+        }
+
+        [Test]
+        public void Describe_OrdersByPrefix()
+        {
+            List<EventDomain> domains = EventDomainCatalog.Describe(new[]
+            {
+                typeof(DomainUnmarkedTestEvents), typeof(DomainListingTestEvents), typeof(DomainPrefixOverrideTestEvents),
+            });
+
+            Assert.AreEqual("DomainListingPrefixed", domains[0].Prefix);
+            Assert.AreEqual("DomainListingTestEvents", domains[1].Prefix);
+            Assert.AreEqual("DomainUnmarkedTestEvents", domains[2].Prefix);
+        }
+
+        [Test]
+        public void Format_NamesThePrefixAndTheFullTypeName()
+        {
+            string line = EventDomainCatalog.Format(Describe(typeof(DomainListingTestEvents)));
+
+            StringAssert.Contains("DomainListingTestEvents/", line);
+            StringAssert.Contains(typeof(DomainListingTestEvents).FullName, line);
+            StringAssert.Contains("3 member(s)", line);
+        }
+
+        [Test]
+        public void SweepThenDescribe_SummarisesWhatTheRegistryHolds()
+        {
+            // What the menu does, without the editor API: sweep, then summarise the registry itself.
+            EventsRegistry.RegisterAnnotatedEventEnums();
+
+            EventDomain domain = Find(EventDomainCatalog.Describe(EventsRegistry.RegisteredEnumTypes),
+                                      typeof(DomainListingTestEvents));
+
+            Assert.AreEqual("DomainListingTestEvents", domain.Prefix);
+            Assert.AreEqual(3, domain.MemberCount);
+        }
+    }
+}

--- a/Tests/Editor/EventDomainsTests.cs.meta
+++ b/Tests/Editor/EventDomainsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 26924b17bba3aef76ed94ca88d553dea

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.crawfissoftware.eventspublisher",
   "displayName": "Events Publisher",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "unity": "2022.3",
   "description": "Lightweight, allocation-safe event/messaging publisher for Unity projects. Editor tooling included.",
   "keywords": [ "events", "messaging", "publisher", "observer", "csharp", "unity" ],


### PR DESCRIPTION
## What was missing

`EventsRegistry` could report an event's delivery policy, its payload type, and the prefix a given enum projects onto — but not *which* enums had registered. Anything wanting to describe a project's event domains (an editor tool, a diagnostic, an assistant reading a project it has never seen) had to run a reflection sweep of its own and hope it agreed with the runtime. That is the same drift `EventNameCatalog` exists to prevent on the projection: a listing that quietly disagrees with the registry is worse than no listing.

## The addition

**`EventsRegistry.RegisteredEnumTypes`** — every enum family that has registered, as a read-only collection.

- Recorded in `ClaimPrefix`, the one call site that already sees `(prefix, enumType)` at registration; cleared in `ResetStaticState` next to the prefixes it is recorded alongside.
- The prefix stays available through the existing public `GetPrefix(Type)`, so this adds one member rather than two.
- **Both sides of a prefix collision are listed.** Only the first claimant holds the prefix, but both families registered and both publish under it — listing only the winner would hide the half of the collision that is surprising.
- The wrapper is built once, so every read hands back the same collection rather than a snapshot. It is live behind that reference, and the one way that bites — registering a family while walking it — is documented. Nothing here is synchronized, in line with the rest of the registry, and the remarks say so rather than implying a guarantee the type does not make.

**`CrawfisSoftware > Events > List Domains`** — one console line per registered domain:

```
GameFlowEvents/  —  MyGame.Flow.GameFlowEvents  —  7 member(s), 2 with [EventPayload], 3 Sticky, 0 Replay
```

- Console rather than a window, matching `List Current Subscribers`.
- Nothing sweeps in edit mode — the sweep runs before the first scene loads — so the menu runs *that same sweep* first rather than walking the assemblies its own way. Registering in the editor is the registration play mode performs: it subscribes to nothing, publishes nothing, and entering play mode resets the static state and sweeps again, so nothing it registers can outlive the editor session or reach a build.
- In play mode it also lists the families that registered lazily on first touch, which no scan for `[EventEnum]` can see.
- `EventDomainCatalog` holds the summary and the line format, free of editor APIs, the way `EventsUpgradeAudit` splits from its window. Reaching the sweep needs `InternalsVisibleTo` for the editor assembly; the sweep stays off the public API for the same reason the reset does.

## Verification (real editor, Unity 6000.5.7f1, EditMode)

| Check | Result |
|---|---|
| Full suite | **122/122** (109 pre-existing + 13 new), no new compile warnings |
| `EditorApplication.ExecuteMenuItem("CrawfisSoftware/Events/List Domains")` | returned `true`, printed 9 domains in edit mode |
| Unity-generated files in the package | none — the three hand-written `.meta` files are complete |

The menu probe is the part worth calling out: it proves the sweep-then-report path works *outside* play mode, which is the only mode the menu is used in and the one the registry is empty in.

### The 13 new tests

A marked family appears once the sweep has run and an unmarked one from its first touch; the prefix override is reported **and pinned against the runtime projection**; re-registration lists a family once; colliding families are both listed; reset empties the list; the collection is the same each read and cannot be mutated through its reference; plus the counts, the ordering, the null/non-enum cases, and the line format.

## Notes

- **Additive**: no existing public member changed, so a 2.4.x consumer that upgrades and changes nothing keeps working.
- A `Replay` count sits alongside the `[EventPayload]` and `Sticky` counts — a Sticky-only column reads as "nothing retained" for a domain whose members are all `Replay`.
- An aliased enum member's `[EventDelivery]` / `[EventPayload]` is counted in the listing but never read by the registry, which resolves a shared value back to the first-declared member. Documented on `EventDomain` rather than worked around; the upgrade audit counts declared fields the same way.
- Consumer follow-up (not in this PR): `EndlessRunnerTemplate`'s CLAUDE.md "Essential Commands" block wants a `List Domains: CrawfisSoftware > Events > List Domains` line once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
