### PR TITLE
Skip test assemblies when sweeping for event enums; release 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1] - 2026-08-29
+
+### Fixed
+
+- This package's own test fixtures registered as event domains in any project that listed it
+  in `testables`. Nine enums in `CrawfisSoftware.EventsPublisher.Tests` are marked
+  `[EventEnum]` — the sweep tests need them to be — and the `BeforeSceneLoad` sweep walked
+  every assembly in the AppDomain without asking where a family came from. On entering play
+  mode they claimed prefixes in the project's own event namespace, and they surfaced in all
+  three places `[EventEnum]` is discovered: **List Domains**, the Inspector event-name
+  dropdowns, and the **Upgrade Audit** window. A consumer with three real domains saw twelve,
+  and could point a serialized event field at `SweptTestEvents/One` — a name nothing
+  publishes, failing silently at runtime with no error to follow.
+
+  The sweep and both editor discovery sites now skip test assemblies, identified by a
+  reference to `nunit.framework`. The rule covers a *consuming* project's test assemblies
+  too, so a fixture marked `[EventEnum]` in your own EditMode tests no longer leaks into your
+  domain listing. Nothing changes for a project that does not compile test assemblies, and
+  builds were never affected — test assemblies are editor-only.
+
+  Removing the package from `testables` was the only workaround, at the cost of not being
+  able to run its tests; that is no longer necessary.
+
+### Added
+
+- `EventsRegistry.RegisterAnnotatedEventEnums(IEnumerable<Assembly>)` — the sweep over an
+  explicit set of assemblies. The parameterless entry point is now the filtering boundary and
+  delegates to it, which is what keeps the exclusion testable: the tests that assert a marked
+  family registers hand the sweep their own assembly, precisely the one the entry point drops.
+  Internal, like the sweep it splits.
+- `EventsRegistry.IsTestAssembly(Assembly)` — the single definition of that rule, shared by
+  the runtime sweep and the two editor tools rather than each testing for it their own way.
+  Internal.
+- 3 EditMode tests pinning the exclusion end to end — the sweep skips a marked fixture, the
+  domain listing reports no fixture, and the predicate tells the suite from the package —
+  bringing the suite to 125.
+
 ## [2.5.0] - 2026-08-27
 
 Additive: nothing was removed or changed, so a 2.4.x consumer that upgrades and changes nothing

--- a/Editor/EventNameCatalog.cs
+++ b/Editor/EventNameCatalog.cs
@@ -17,6 +17,10 @@ namespace CrawfisSoftware.Events.Editor
     /// <para>Marking an enum <see cref="EventEnumAttribute"/> is the opt-in. An enum with no attribute
     /// contributes nothing, and a serialized value naming one of its members is treated as unknown —
     /// shown as missing, never silently cleared.</para>
+    /// <para>A marked enum in a test assembly contributes nothing either, matching the runtime sweep.
+    /// Offering a fixture here would let an Inspector field be pointed at an event that no shipping
+    /// code publishes, which fails silently at runtime — the exact outcome the projection above is
+    /// kept single-definition to prevent.</para>
     /// </remarks>
     internal static class EventNameCatalog
     {
@@ -30,7 +34,14 @@ namespace CrawfisSoftware.Events.Editor
                 if (_cached == null)
                 {
                     // TypeCache is maintained by the editor and is far cheaper than walking assemblies.
-                    var enumTypes = new List<Type>(TypeCache.GetTypesWithAttribute<EventEnumAttribute>());
+                    // Filtered here rather than in BuildNames: the projection is the tested core and
+                    // takes whatever types it is handed, so the rule about which types to offer belongs
+                    // at the boundary that discovers them.
+                    var enumTypes = new List<Type>();
+                    foreach (Type type in TypeCache.GetTypesWithAttribute<EventEnumAttribute>())
+                    {
+                        if (!EventsRegistry.IsTestAssembly(type.Assembly)) enumTypes.Add(type);
+                    }
                     _cached = BuildNames(enumTypes);
                 }
                 return _cached;

--- a/Editor/EventsUpgradeAuditWindow.cs
+++ b/Editor/EventsUpgradeAuditWindow.cs
@@ -110,23 +110,32 @@ namespace CrawfisSoftware.Events.Editor
         {
             var found = new List<Type>();
             foreach (Type type in TypeCache.GetTypesDerivedFrom(typeof(EventsPublisherEnumsSingleton<>)))
-                if (!type.IsAbstract) found.Add(type);
+                if (!type.IsAbstract && !EventsRegistry.IsTestAssembly(type.Assembly)) found.Add(type);
             return found;
         }
 
         /// <summary>
         /// Finds every enum acting as an event family, whether or not it is marked yet.
         /// </summary>
-        /// <remarks>Three sources, because a project part-way through the migration has families in
+        /// <remarks>
+        /// <para>Three sources, because a project part-way through the migration has families in
         /// each: already marked with the attribute, still behind a singleton subclass, and named in a
         /// <c>EventsFor&lt;T&gt;</c> type argument in source. The last needs a source scan — a type
-        /// argument leaves no trace this tool can reflect over.</remarks>
+        /// argument leaves no trace this tool can reflect over.</para>
+        /// <para>Test assemblies are excluded from the two reflected sources, as they are from the
+        /// runtime sweep. The audit advises a project on its own migration, and a fixture is not part
+        /// of what there is to migrate: reporting one would be a finding no consumer could act on. The
+        /// source scan needs no such filter — it reads <c>Assets</c> only.</para>
+        /// </remarks>
         private static List<Type> CollectEventEnums(List<Type> singletons)
         {
             var found = new List<Type>();
             var seen = new HashSet<Type>();
 
-            foreach (Type type in TypeCache.GetTypesWithAttribute<EventEnumAttribute>()) AddEnum(found, seen, type);
+            foreach (Type type in TypeCache.GetTypesWithAttribute<EventEnumAttribute>())
+            {
+                if (!EventsRegistry.IsTestAssembly(type.Assembly)) AddEnum(found, seen, type);
+            }
 
             foreach (Type subclass in singletons)
             {

--- a/Runtime/EventsRegistry.cs
+++ b/Runtime/EventsRegistry.cs
@@ -311,14 +311,36 @@ namespace CrawfisSoftware.Events
         /// <summary>
         /// Registers every enum marked with <see cref="EventEnumAttribute"/> before the first scene loads.
         /// </summary>
-        /// <remarks>See <see cref="EventEnumAttribute"/> for why this exists when
-        /// <see cref="EventsFor{T}"/> already registers lazily on first use.</remarks>
+        /// <remarks>
+        /// <para>See <see cref="EventEnumAttribute"/> for why this exists when
+        /// <see cref="EventsFor{T}"/> already registers lazily on first use.</para>
+        /// <para>Test assemblies are skipped, per <see cref="IsTestAssembly"/>. An event family is a
+        /// fact about a project, and a fixture that exists to exercise this sweep is not one:
+        /// registering it claims a prefix in the project's event namespace, lists it under
+        /// <c>List Domains</c>, and offers its members in the Inspector dropdowns — all of it
+        /// describing events that nothing will ever publish. This package's own fixtures reached
+        /// consumer projects exactly that way, through <c>testables</c>.</para>
+        /// </remarks>
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         internal static void RegisterAnnotatedEventEnums()
         {
-            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            RegisterAnnotatedEventEnums(NonTestAssemblies(AppDomain.CurrentDomain.GetAssemblies()));
+        }
+
+        /// <summary>
+        /// Registers every <see cref="EventEnumAttribute"/>-marked enum in the given assemblies.
+        /// </summary>
+        /// <remarks>Takes the assemblies rather than reading the AppDomain itself, so that the
+        /// filtering lives at the entry point and this stays exercisable: the tests that assert a
+        /// marked family registers hand it their own assembly, which is precisely the assembly the
+        /// entry point excludes.</remarks>
+        internal static void RegisterAnnotatedEventEnums(IEnumerable<Assembly> assemblies)
+        {
+            if (assemblies == null) return;
+
+            foreach (Assembly assembly in assemblies)
             {
-                if (assembly.IsDynamic) continue;
+                if (assembly == null || assembly.IsDynamic) continue;
 
                 Type[] types;
                 // A single unloadable dependency must not stop the sweep; take whatever loaded.
@@ -345,6 +367,45 @@ namespace CrawfisSoftware.Events
                 }
             }
         }
+
+        /// <summary>Yields the assemblies that can hold event families, dropping the test ones.</summary>
+        private static IEnumerable<Assembly> NonTestAssemblies(Assembly[] assemblies)
+        {
+            foreach (Assembly assembly in assemblies)
+            {
+                if (!IsTestAssembly(assembly)) yield return assembly;
+            }
+        }
+
+        /// <summary>
+        /// Whether an assembly is a test assembly, and therefore not a source of event families.
+        /// </summary>
+        /// <remarks>
+        /// <para>Keyed on a reference to NUnit, which every Unity test assembly carries — the Test
+        /// Framework compiles them against it — and which no shipping assembly has reason to.</para>
+        /// <para>Reflection rather than <c>UnityEditor.Compilation.AssemblyFlags</c> because this runs
+        /// in the runtime assembly, which cannot reference the editor. The editor tools call this
+        /// rather than testing for a test assembly their own way, so there is one definition of the
+        /// rule instead of three that could disagree about which fixtures are hidden.</para>
+        /// </remarks>
+        internal static bool IsTestAssembly(Assembly assembly)
+        {
+            if (assembly == null) return false;
+
+            AssemblyName[] references;
+            // Same reasoning as the GetTypes guard: an assembly whose manifest cannot be read is no
+            // reason to stop, and treating it as non-test only risks listing a family that is real.
+            try { references = assembly.GetReferencedAssemblies(); }
+            catch (Exception) { return false; }
+
+            foreach (AssemblyName reference in references)
+            {
+                if (string.Equals(reference.Name, NUnitAssemblyName, StringComparison.Ordinal)) return true;
+            }
+            return false;
+        }
+
+        private const string NUnitAssemblyName = "nunit.framework";
 
         internal const string EnsureRegisteredMethodName = "EnsureRegistered";
     }

--- a/Tests/Editor/EventDomainsTests.cs
+++ b/Tests/Editor/EventDomainsTests.cs
@@ -67,9 +67,30 @@ namespace CrawfisSoftware.Events.Tests
             // the menu sweeps before reading it rather than assuming something already has.
             CollectionAssert.DoesNotContain(EventsRegistry.RegisteredEnumTypes, typeof(DomainListingTestEvents));
 
-            EventsRegistry.RegisterAnnotatedEventEnums();
+            EventsRegistry.RegisterAnnotatedEventEnums(OwnAssembly);
 
             CollectionAssert.Contains(EventsRegistry.RegisteredEnumTypes, typeof(DomainListingTestEvents));
+        }
+
+        [Test]
+        public void TheListing_ExcludesFixturesFromTheTestAssembly()
+        {
+            // The symptom the exclusion exists for: "CrawfisSoftware > Events > List Domains" in a
+            // consuming project printed this suite's fixtures alongside the project's own domains,
+            // which makes the listing useless as the authoritative answer to "what domains are there".
+            // The real entry point, so what is covered is the filtering as it actually runs. It sweeps
+            // the whole AppDomain, which in a consuming project registers that project's own families
+            // too — and anything they log on the way would otherwise fail this test for reasons that
+            // have nothing to do with it. The assertion below is what this test is about.
+            LogAssert.ignoreFailingMessages = true;
+            try { EventsRegistry.RegisterAnnotatedEventEnums(); }
+            finally { LogAssert.ignoreFailingMessages = false; }
+
+            foreach (EventDomain domain in EventDomainCatalog.Describe(EventsRegistry.RegisteredEnumTypes))
+            {
+                Assert.AreNotEqual(typeof(EventsTestBase).Assembly, domain.EnumType.Assembly,
+                                   "the listing must not report the fixture " + domain.EnumType.FullName);
+            }
         }
 
         [Test]
@@ -77,7 +98,7 @@ namespace CrawfisSoftware.Events.Tests
         {
             // [EventEnum] governs when a family registers, not whether it counts as a domain: an unmarked
             // one is a domain from the moment its facade is built, and the listing must say so.
-            EventsRegistry.RegisterAnnotatedEventEnums();
+            EventsRegistry.RegisterAnnotatedEventEnums(OwnAssembly);
             CollectionAssert.DoesNotContain(EventsRegistry.RegisteredEnumTypes, typeof(DomainUnmarkedTestEvents));
 
             EventsFor<DomainUnmarkedTestEvents>.EnsureRegistered();
@@ -200,7 +221,7 @@ namespace CrawfisSoftware.Events.Tests
         public void SweepThenDescribe_SummarisesWhatTheRegistryHolds()
         {
             // What the menu does, without the editor API: sweep, then summarise the registry itself.
-            EventsRegistry.RegisterAnnotatedEventEnums();
+            EventsRegistry.RegisterAnnotatedEventEnums(OwnAssembly);
 
             EventDomain domain = Find(EventDomainCatalog.Describe(EventsRegistry.RegisteredEnumTypes),
                                       typeof(DomainListingTestEvents));

--- a/Tests/Editor/EventsForTests.cs
+++ b/Tests/Editor/EventsForTests.cs
@@ -62,10 +62,37 @@ namespace CrawfisSoftware.Events.Tests
 
             // [EventEnum] covers the one case lazy initialization cannot: a name reaching the publisher
             // as a raw string, from a serialized Inspector field, without the facade ever being touched.
-            EventsRegistry.RegisterAnnotatedEventEnums();
+            EventsRegistry.RegisterAnnotatedEventEnums(OwnAssembly);
 
             Bus.PublishEvent("SweptTestEvents/One", "probe", null);
             LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void TheSweep_SkipsTestAssemblies()
+        {
+            // The fixtures in this suite are marked [EventEnum] because the sweep tests need them to
+            // be. That must not make them events in a consuming project: until the entry point learned
+            // to skip test assemblies, a project listing this package in "testables" got nine of these
+            // fixtures registered as real domains at BeforeSceneLoad.
+            // The real entry point, so what is covered is the filtering as it actually runs. It sweeps
+            // the whole AppDomain, which in a consuming project registers that project's own families
+            // too — and anything they log on the way would otherwise fail this test for reasons that
+            // have nothing to do with it. The assertion below is what this test is about.
+            LogAssert.ignoreFailingMessages = true;
+            try { EventsRegistry.RegisterAnnotatedEventEnums(); }
+            finally { LogAssert.ignoreFailingMessages = false; }
+
+            CollectionAssert.DoesNotContain(EventsRegistry.RegisteredEnumTypes, typeof(SweptTestEvents));
+        }
+
+        [Test]
+        public void IsTestAssembly_TellsThisSuiteFromThePackage()
+        {
+            // The rule is a reference to NUnit, so it holds for any consumer's test assembly too —
+            // a student's fixture marked [EventEnum] stays out of their own project's listing.
+            Assert.IsTrue(EventsRegistry.IsTestAssembly(typeof(EventsForTests).Assembly));
+            Assert.IsFalse(EventsRegistry.IsTestAssembly(typeof(EventsRegistry).Assembly));
         }
 
         [Test]

--- a/Tests/Editor/EventsTestBase.cs
+++ b/Tests/Editor/EventsTestBase.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Reflection;
 
 using NUnit.Framework;
 
@@ -16,6 +17,14 @@ namespace CrawfisSoftware.Events.Tests
     {
         /// <summary>Collects handler invocations as <c>"tag:data"</c> so order can be asserted.</summary>
         protected List<string> Log { get; private set; }
+
+        /// <summary>This suite's own assembly, for handing to the sweep directly.</summary>
+        /// <remarks>The parameterless <see cref="EventsRegistry.RegisterAnnotatedEventEnums()"/> entry
+        /// point excludes test assemblies — that exclusion is what keeps these fixtures out of a
+        /// consuming project's domain listing and Inspector dropdowns — so a test that needs the sweep
+        /// to see its own fixtures asks for them by name rather than relying on ambient AppDomain
+        /// state, which is the more honest thing for those tests to assert anyway.</remarks>
+        protected static readonly Assembly[] OwnAssembly = { typeof(EventsTestBase).Assembly };
 
         protected static IStackEventsPublisher<string> Bus => EventsPublisher.Instance;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.crawfissoftware.eventspublisher",
   "displayName": "Events Publisher",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "unity": "2022.3",
   "description": "Lightweight, allocation-safe event/messaging publisher for Unity projects. Editor tooling included.",
   "keywords": [ "events", "messaging", "publisher", "observer", "csharp", "unity" ],


### PR DESCRIPTION
## The problem

This package's own test fixtures registered as event domains in any project that listed it in `testables`.

Nine enums in `CrawfisSoftware.EventsPublisher.Tests` are marked `[EventEnum]` — the sweep tests need them to be — and `RegisterAnnotatedEventEnums()` walked every assembly in the AppDomain without asking where a family came from. On entering play mode they claimed prefixes in the *consuming* project's event namespace and surfaced in all three places `[EventEnum]` is discovered:

- **CrawfisSoftware > Events > List Domains** — a project with three real domains listed twelve
- **The Inspector event-name dropdowns** — a serialized field could be pointed at `SweptTestEvents/One`, a name nothing publishes, failing silently at runtime with no error to follow
- **Window > Events > Upgrade Audit**

Compounding it, the audit emits an `Action` finding telling a project to *add* the `testables` entry that causes this.

## Why not a separate test-only attribute

Marking the fixtures `[EventTestEnum]` instead looks like the root fix, but cannot be one. Two of them carry `[EventEnum(Prefix = …)]`, and `GetPrefix` reads the override off that attribute alone — swapping it would silently rename their events and break the collision tests. A third, `AuditMarkedEvents`, is the input to the audit's own "is this type marked?" check. Those three would have kept leaking, so the rule has to be about *where a family comes from*, not how it is marked.

## The change

**Runtime** — `RegisterAnnotatedEventEnums()` becomes the filtering boundary and delegates to a new internal overload taking assemblies explicitly. That split is what keeps the exclusion testable: the tests asserting a marked family registers hand the sweep their own assembly, precisely the one the entry point drops. `IsTestAssembly(Assembly)` is keyed on a reference to `nunit.framework` — plain reflection, because this runs in the runtime assembly and cannot reference `UnityEditor.Compilation`.

**Editor** — the same predicate at the three `TypeCache` sites in `EventNameCatalog` and the Upgrade Audit window, so there is one definition of the rule rather than three that could drift. Applied at those boundaries and never inside `BuildNames` or `Audit()`, which are the tested cores and take whatever types they are handed.

**Tests** — the four sweep call sites pass the suite's own assembly via a new `EventsTestBase.OwnAssembly`, so they no longer depend on ambient AppDomain state. Three new tests pin the exclusion end to end. Suite 122 → 125.

## Scope

The rule covers a **consuming project's** test assemblies too, so a fixture marked `[EventEnum]` in a project's own EditMode tests no longer leaks into its domain listing either. Nothing changes for a project that compiles no test assemblies, and builds were never affected — test assemblies are editor-only.

Removing the package from `testables` was the only workaround, at the cost of not being able to run its tests. That is no longer necessary.

## Verification

Compile-checked all three assemblies against Unity 6000.5.7f1, then run in a real editor (EditMode) from a consuming project resolving this branch locally: **126/126 pass** (125 from this suite, 1 from an unrelated Addressables doc-example test in that project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHn4ZNS62UPMt5YnsCkran