### PR TITLE
Clear events on leaving play mode unconditionally; deprecate EventsPublisherEnumsSingleton<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-09-02
+
+### Fixed
+
+- **Events were never cleared when play mode ended.** `ClearEventsMenu` is
+  `[InitializeOnLoad]`, but the method that subscribes to
+  `EditorApplication.playModeStateChanged` was named `EventLoggingMenu()` — the name of the
+  class it was copied from — so it was an ordinary private method rather than the static
+  constructor `[InitializeOnLoad]` calls, and nothing ever registered the handler. The
+  **Clear Events on Exiting Play Mode** toggle it guarded could not be switched on either:
+  the menu item had a `[MenuItem(..., true)]` validator but no action method, so clicking it
+  did nothing and it always read as off. The feature had never run in any project.
+
+### Changed
+
+- **Clearing on leaving play mode is now unconditional**, and the toggle is gone with it.
+  `EventsPublisher` is static state that `EventsRegistry.ResetStaticState` deliberately did
+  not touch, so with *Enter Play Mode Options* set to skip the domain reload it carried the
+  previous session's subscriptions — delegates bound to destroyed objects — into the next
+  run. Clearing explicitly rather than relying on the domain reload keeps this correct
+  whichever way that project setting is set, which is the same reasoning the registry reset
+  already followed.
+
+  The clear runs at `EnteredEditMode` rather than `ExitingPlayMode`, which is the point
+  teardown has finished: an `OnDestroy` that unsubscribes, or that publishes a shutdown
+  event, still sees the subscribers it expects. It clears subscriptions, registered names
+  and retained values on every frame of the publisher stack; it does not unwind the stack
+  itself, so a frame pushed and never popped survives, empty.
+
+  What this costs: **List Current Subscribers** reports nothing once play mode has ended.
+  Inspect a subscription leak while still in play mode.
+
+- `ClearEventsMenu.IsEnabled` is removed along with the toggle it backed. Public, and
+  therefore a source-breaking change in principle, but it was editor-only `SessionState`
+  and nothing could set it.
+
+### Deprecated
+
+- `EventsPublisherEnumsSingleton<T>` is `[Obsolete]`, so every remaining subclass
+  declaration now reports itself as a compiler warning. Use `EventsFor<T>`: static, lazily
+  initialized, needs no GameObject and no `[DefaultExecutionOrder]`, so the `Awake` race the
+  singleton's subclasses worked around cannot occur. Behavior is unchanged — the singleton
+  still forwards to the same facade — and **Window > Events > Upgrade Audit** lists the
+  subclasses to replace and what removing them touches in your scenes.
+
+  Deprecated rather than removed because a subclass is a `MonoBehaviour`: deleting the type
+  orphans every instance authored into a scene or prefab, which is an asset edit each
+  consumer has to make on their own schedule. Removal is planned for 3.0.
+
 ## [2.5.1] - 2026-08-29
 
 ### Fixed

--- a/Documentation~/UPGRADING.md
+++ b/Documentation~/UPGRADING.md
@@ -96,7 +96,8 @@ GameFlowBus.Publish(GameFlowEvents.GameStarting, this, null);
 
 Then delete the singleton subclasses and the execution-order attributes. The old
 singleton still works and forwards to the same facade, so the call sites can move file by
-file.
+file. As of 2.6.0 it is `[Obsolete]`, so each remaining subclass declaration reports itself
+as a compiler warning; removal is planned for 3.0.
 
 The deletion itself is not code-only, which is easy to miss. A subclass is a
 `MonoBehaviour`, so removing it orphans every instance authored into a scene and leaves a

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -465,6 +465,16 @@ value lives in the publisher frame that was top when it was published, and `Pop(
 discards it. `Clear()` drops retained state too, and `ClearEventsMenu`'s existing
 "clear on exiting play mode" toggle already covers the editor loop.
 
+#### Correction: the toggle covered nothing
+
+That last claim was wrong, and was checked no further than the toggle's existence. The
+handler was never registered — `ClearEventsMenu` is `[InitializeOnLoad]`, but its
+would-be static constructor carried the name of the class it was copied from, making it
+an ordinary private method — and the menu item had a validator but no action, so the
+toggle could not be switched on either. It had never run in any project. Fixed in 2.6.0,
+where the clear is unconditional and runs at `EnteredEditMode`, after teardown, so an
+`OnDestroy` that unsubscribes or publishes still sees the subscribers it expects.
+
 #### Correction: retention is top-frame only, not per-frame
 
 An earlier draft said a retained value "lives in the frame it was published into"
@@ -606,6 +616,13 @@ Two supporting pieces:
   cached facades and prefix claims. A no-op when domain reload is enabled (the current
   setting), correct when it is not. It deliberately does **not** clear
   `EventsPublisher` itself; dropping live subscriptions stays the opt-in editor toggle.
+  **Revised in 2.6.0** — the toggle was dead code (see *Correction: the toggle covered
+  nothing*), and an opt-in default left the publisher carrying a dead session's
+  subscribers whenever the domain reload is skipped. The editor now clears it
+  unconditionally once play mode ends. The runtime reset still does not touch the
+  publisher: within a *build*, ordering among `SubsystemRegistration` entry points is
+  undefined, so clearing there could discard a subscription made by a consumer's own
+  entry point in the same phase.
 
 #### Defect found and fixed in the Stage 0 collision detector
 

--- a/Editor/ClearEventsMenu.cs
+++ b/Editor/ClearEventsMenu.cs
@@ -2,20 +2,41 @@ using UnityEditor;
 
 namespace CrawfisSoftware.Events.Editor
 {
+    /// <summary>
+    /// Menu entry points for inspecting the publisher, and the clear that runs when play mode ends.
+    /// </summary>
+    /// <remarks>
+    /// <para>The clear used to sit behind a "Clear Events on Exiting Play Mode" toggle that defaulted
+    /// off, and that never actually ran: the method wired to
+    /// <see cref="EditorApplication.playModeStateChanged"/> carried the name of the class it was copied
+    /// from, so it was an ordinary private method rather than the static constructor
+    /// <c>[InitializeOnLoad]</c> calls, and the toggle's menu item had a validator but no action, so it
+    /// could not be switched on either.</para>
+    /// <para>It is now unconditional. With <em>Enter Play Mode Options</em> set to skip the domain
+    /// reload, statics survive between play sessions, so <see cref="EventsPublisher"/> would otherwise
+    /// carry the previous session's subscriptions — delegates bound to destroyed objects — into the
+    /// next one. <c>EventsRegistry.ResetStaticState</c> already drops the rest of the package's static
+    /// state at <c>SubsystemRegistration</c>; this is the publisher's half of the same job, and doing
+    /// it unconditionally keeps it correct whatever that project setting says.</para>
+    /// <para>It runs at <see cref="PlayModeStateChange.EnteredEditMode"/> rather than
+    /// <see cref="PlayModeStateChange.ExitingPlayMode"/>, which is the point teardown has finished: an
+    /// <c>OnDestroy</c> that unsubscribes, or that publishes a shutdown event, still sees the
+    /// subscribers it expects. The cost is that <b>List Current Subscribers</b> reports nothing once
+    /// play mode has ended — inspect a subscription leak while still in play mode.</para>
+    /// <para>This clears subscriptions, registered names and retained values on every frame of the
+    /// publisher stack. It does not unwind the stack itself: a frame pushed and never popped survives,
+    /// empty, which is harmless but is not what the code that pushed it intended.</para>
+    /// </remarks>
     [InitializeOnLoad]
     public class ClearEventsMenu : EditorWindow
     {
         private const string CLEAR_NOW_MENU_LOCATION = "CrawfisSoftware/Events/Clear Now";
         private const string LIST_SUBSCRIBERS_MENU_LOCATION = "CrawfisSoftware/Events/List Current Subscribers";
-        private const string TOGGLE_MENU_LOCATION = "CrawfisSoftware/Events/Clear Events on Exiting Play Mode";
-        private const string SettingName = "DoClearEvents";
 
-        public static bool IsEnabled
+        static ClearEventsMenu()
         {
-            get { return SessionState.GetBool(SettingName, false); }
-            set { SessionState.SetBool(SettingName, value); }
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
         }
-
 
         [MenuItem(CLEAR_NOW_MENU_LOCATION)]
         private static void Clear()
@@ -37,21 +58,9 @@ namespace CrawfisSoftware.Events.Editor
             UnityEngine.Debug.Log($"   ....  {count} subscribers listed");
         }
 
-        [MenuItem(TOGGLE_MENU_LOCATION, true)]
-        private static bool ToggleActionValidate()
-        {
-            Menu.SetChecked(TOGGLE_MENU_LOCATION, IsEnabled);
-            return true;
-        }
-
-        static void EventLoggingMenu()
-        {
-            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
-        }
-
         private static void OnPlayModeStateChanged(PlayModeStateChange state)
         {
-            if (state == PlayModeStateChange.ExitingPlayMode && IsEnabled)
+            if (state == PlayModeStateChange.EnteredEditMode)
             {
                 EventsPublisher.Instance.Clear();
             }

--- a/Editor/EventsUpgradeAuditWindow.cs
+++ b/Editor/EventsUpgradeAuditWindow.cs
@@ -106,10 +106,15 @@ namespace CrawfisSoftware.Events.Editor
             };
         }
 
+        // The obsolete warning is suppressed here and at the base-type walk below: naming the
+        // deprecated type is what this tool is for, and a report that cannot mention what it
+        // reports on would be useless.
         private static List<Type> CollectSingletonSubclasses()
         {
             var found = new List<Type>();
+#pragma warning disable 618
             foreach (Type type in TypeCache.GetTypesDerivedFrom(typeof(EventsPublisherEnumsSingleton<>)))
+#pragma warning restore 618
                 if (!type.IsAbstract && !EventsRegistry.IsTestAssembly(type.Assembly)) found.Add(type);
             return found;
         }
@@ -141,7 +146,9 @@ namespace CrawfisSoftware.Events.Editor
             {
                 for (Type baseType = subclass.BaseType; baseType != null; baseType = baseType.BaseType)
                 {
+#pragma warning disable 618
                     if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == typeof(EventsPublisherEnumsSingleton<>))
+#pragma warning restore 618
                     {
                         AddEnum(found, seen, baseType.GetGenericArguments()[0]);
                         break;

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ private void Die()
 }
 ```
 
-`EventsPublisherEnumsSingleton<T>` still works and forwards to the same facade, so
-existing scene objects keep running unchanged.
+`EventsPublisherEnumsSingleton<T>` is deprecated as of 2.6.0 and will be removed in 3.0.
+It still works and forwards to the same facade, so existing scene objects keep running
+unchanged — but a subclass now compiles with an obsolete warning. **Window > Events >
+Upgrade Audit** lists the subclasses to replace and what removing them touches in your
+scenes.
 
 ## Delivery policy
 
@@ -177,6 +180,13 @@ reports publishing an event name no frame has registered. Without it, a misspell
 reaches no subscriber while still notifying "all events" subscribers, so the logger
 prints it and the system looks healthy. It also reports a publish whose payload is not
 what the event declared it carries, naming the sender.
+
+**CrawfisSoftware > Events** also has *Log Events* (logs every publish while in play
+mode), *List Current Subscribers*, and *Clear Now*. Subscriptions, registered names and
+retained values are cleared automatically once play mode ends — unconditionally as of
+2.6.0, because with *Enter Play Mode Options* set to skip the domain reload the publisher
+is static state that would otherwise carry a dead session's subscribers into the next run.
+Inspect a subscription leak while still in play mode; afterwards there is nothing to list.
 
 ## Upgrading an existing project
 

--- a/Runtime/EventsPublisherEnumsSingleton.cs
+++ b/Runtime/EventsPublisherEnumsSingleton.cs
@@ -17,7 +17,16 @@ namespace CrawfisSoftware.Events
     /// and lazily initialized, so that race cannot occur.</para>
     /// <para>Every member here now forwards to <see cref="EventsFor{T}"/>, so the two paths share one
     /// facade and cannot disagree. Existing scene objects keep working unchanged during migration.</para>
+    /// <para><b>Deprecated as of 2.6.0</b>, and scheduled for removal in 3.0. It is deprecated rather
+    /// than removed because a subclass is a <see cref="MonoBehaviour"/>: deleting the type orphans
+    /// every instance authored into a scene or prefab, which is an asset edit each consumer has to
+    /// make on their own schedule. <c>Window &gt; Events &gt; Upgrade Audit</c> lists the subclasses
+    /// still present and what removing them touches.</para>
     /// </remarks>
+    [Obsolete("Use EventsFor<T>: it is static and lazily initialized, so it needs no GameObject and " +
+              "no [DefaultExecutionOrder], and the Awake race this type's subclasses worked around " +
+              "cannot occur. Window > Events > Upgrade Audit lists the subclasses to replace and what " +
+              "removing them touches in your scenes. Scheduled for removal in 3.0.")]
     public class EventsPublisherEnumsSingleton<T> : MonoBehaviour where T : Enum
     {
         public static EventsPublisherEnumsSingleton<T> Instance { get; private set; }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.crawfissoftware.eventspublisher",
   "displayName": "Events Publisher",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "unity": "2022.3",
   "description": "Lightweight, allocation-safe event/messaging publisher for Unity projects. Editor tooling included.",
   "keywords": [ "events", "messaging", "publisher", "observer", "csharp", "unity" ],


### PR DESCRIPTION
## Why

`EventsPublisher` is static state that `EventsRegistry.ResetStaticState` deliberately does not touch, so with *Enter Play Mode Options* set to skip the domain reload it carried the previous session's subscriptions — delegates bound to destroyed objects — into the next run. The editor toggle that was meant to cover that case **had never run in any project**:

- `ClearEventsMenu` is `[InitializeOnLoad]`, but the method subscribing to `playModeStateChanged` was named `EventLoggingMenu()` — the class it was copied from — so it was an ordinary private method, not the static constructor `[InitializeOnLoad]` calls.
- The toggle's menu item had a `[MenuItem(..., true)]` validator but no action method, so it could not be switched on either.

## What changed

**Clearing is unconditional** (`Editor/ClearEventsMenu.cs`). Real static constructor; the toggle, `SettingName` and the public `IsEnabled` are removed. `IsEnabled` was public and so source-breaking in principle, but it was editor-only `SessionState` that nothing could set.

It runs at `EnteredEditMode`, not `ExitingPlayMode`. The latter fires *before* teardown, so an `OnDestroy` that unsubscribes or publishes a shutdown event would run against an already-emptied publisher. Consequence: **List Current Subscribers** reports nothing once play mode has ended — inspect a leak while still in play mode.

Not moved into `ResetStaticState`: within a build, ordering among `SubsystemRegistration` entry points is undefined, so clearing there could discard a subscription made by a consumer's own entry point in the same phase.

**`EventsPublisherEnumsSingleton<T>` is `[Obsolete]`.** Each remaining subclass declaration now warns. Behavior is unchanged — it still forwards to `EventsFor<T>`. Deprecated rather than removed because a subclass is a `MonoBehaviour`: deleting the type orphans every instance authored into a scene or prefab. Removal planned for 3.0. `EventsUpgradeAuditWindow` suppresses CS0618 at its two `typeof` sites, since naming the deprecated type is what that tool is for.

Docs: CHANGELOG, `package.json` → 2.6.0, README, UPGRADING §4, plus two corrections appended to ADR 0001 (its "Reset scope" section claimed the toggle "already covers the editor loop", which was never true).

## Verification

**Not run in an editor** — no Unity in the environment where this was written. Nothing in `Tests/` references the deprecated type, so the suite should stand at 125, but that is unconfirmed. Before tagging `v2.6.0`, this wants a play-mode round trip in a consuming project with domain reload disabled: enter play mode, subscribe, exit, re-enter, and confirm no stale subscribers survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uWcmpAFqcqjSpcxoA7bLo
