### PR TITLE
Keep declarations across play sessions without domain reload; release 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1] - 2026-09-06
+
+### Fixed
+
+- Entering Play mode with domain reload disabled — Unity 6.6's default for new projects,
+  and the setting Unity now recommends — wiped the wrong things. The
+  `SubsystemRegistration` hook cleared every declaration: delivery policies, payload
+  types, prefix claims, the domain listing. Those come from code, and the static
+  initializers that make them run once per domain, so from the second play on a policy
+  declared with `RegisterEvent(name, policy)` silently reverted to `Transient`, a payload
+  declared with `EventId<T>.Of` silently stopped being checked, and
+  `EventsRegistry.RegisteredEnumTypes` forgot every family until it was touched again.
+  2.6.0's end-of-play clear compounded it by dropping registrations too, so StrictMode
+  reported an imperatively registered event as unregistered on the next play. Reproduced
+  in Unity 6000.6.0f1 with `DisableDomainReload` set.
+
+  The rule is now the same at both ends of a session. *Runtime state* — subscriptions,
+  retained Sticky values and Replay journals, frames pushed above the root, typed-handler
+  wrappers — is dropped once play mode has finished tearing down. *Declarations* —
+  registrations, policies, payload types, prefix claims, the domain listing, interned ids
+  — are kept, because code can only change through a recompile, which always reloads the
+  domain. The play-entry hook resets the diagnostics and nothing else; it no longer
+  touches the publisher at all, so a subscription made by a consumer's own
+  `SubsystemRegistration` entry point cannot be discarded by ordering within that phase.
+  With domain reload enabled nothing changes.
+- `EventsFor<T>.EnsureRegistered()` registers the family on every call rather than only
+  on the one that builds the facade, so the `[EventEnum]` sweep at `BeforeSceneLoad`
+  restores a family's registrations after *Clear Now*.
+
+### Added
+
+- `PlaySessionResetTests` (20) and `ClearEventsMenuTests` (5), bringing the suite to
+  150. The README gains a section on what survives a play session without domain reload,
+  and ADR 0001 records the corrected reset decision.
+
 ## [2.6.0] - 2026-09-02
 
 ### Fixed
@@ -240,6 +275,9 @@ wrong.
 
 - Initial package layout: assembly definitions, editor tooling, event subscriber logging.
 
+[2.6.1]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.6.1
+[2.6.0]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.6.0
+[2.5.1]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.5.1
 [2.5.0]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.5.0
 [2.4.1]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.4.1
 [2.4.0]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.4.0

--- a/Documentation~/UPGRADING.md
+++ b/Documentation~/UPGRADING.md
@@ -47,7 +47,7 @@ Add the package to `testables` in `Packages/manifest.json`:
 { "testables": [ "com.crawfissoftware.eventspublisher" ] }
 ```
 
-Unity only builds a package's tests when the consuming project opts in. 109 EditMode
+Unity only builds a package's tests when the consuming project opts in. 150 EditMode
 tests then appear under **Window > General > Test Runner**. Running them once in your
 project is a genuine check of the project's setup, not a formality.
 
@@ -223,6 +223,15 @@ in a project that still has raw-string publishes** — which most do, and will k
 - **`EventId` needs nothing from you.** The publisher keys on an interned handle
   internally and handler signatures did not change. It only becomes visible if you choose
   to hold one.
+- **Domain reload off is supported from 2.6.1.** Unity 6.6 defaults new projects to
+  entering Play mode without a domain reload. On every play entry, and again once play
+  mode has torn down, the package drops the previous session's subscriptions, retained
+  values and pushed frames, and keeps every declaration — registrations, policies,
+  payload types — so what you declared from a static initializer stays declared. On 2.4.0
+  through 2.6.0 with that setting, a policy declared with `RegisterEvent(name, policy)`
+  reverted to `Transient` on the second play, a payload declared with `EventId<T>.Of`
+  stopped being checked, and until 2.6.0 the previous run's Sticky values leaked into the
+  next; see the README section *Entering Play mode without domain reload*.
 
 ## Turning the diagnostic off
 

--- a/Documentation~/adr/0001-event-identity-and-delivery.md
+++ b/Documentation~/adr/0001-event-identity-and-delivery.md
@@ -623,6 +623,22 @@ Two supporting pieces:
   publisher: within a *build*, ordering among `SubsystemRegistration` entry points is
   undefined, so clearing there could discard a subscription made by a consumer's own
   entry point in the same phase.
+  **Corrected in 2.6.1** — the reset had the halves backwards. The *runtime state* is
+  what must not carry over — subscriptions, retained values, pushed frames, typed
+  wrappers — and the *declarations* are what must: registrations, policies, payload
+  types, prefix claims, the domain listing, interned ids. A declaration derives from
+  code, and code changes only through a recompile, which always reloads the domain; the
+  static initializer that made it will not run again without one. Wiping them at
+  `SubsystemRegistration` therefore reverted an imperatively declared policy to
+  `Transient` on the second play and switched a declared payload type's check off, both
+  silently, and 2.6.0's full `Clear()` at `EnteredEditMode` added a StrictMode report
+  for every imperatively registered event. Reproduced in Unity 6000.6.0f1 with domain
+  reload off. `EventsRegistry.BeginPlaySession` (the `SubsystemRegistration` hook) now
+  resets the diagnostics and nothing else — the ordering argument above stands, and
+  applies to declarations just as much as to subscriptions — and
+  `EventsRegistry.EndPlaySession`, called by the editor at `EnteredEditMode`, drops the
+  runtime state and keeps the declarations. Pinned by `PlaySessionResetTests` and
+  `ClearEventsMenuTests`.
 
 #### Defect found and fixed in the Stage 0 collision detector
 
@@ -728,11 +744,12 @@ consumers continue to compile.
 
 ### Tests
 
-`Tests/Editor` holds 109 EditMode tests across ten fixtures, covering dispatch ordering
-and isolation, the re-entrant publish completion contract, the static facade and its
-registration timing, all three delivery policies, the interned identity, the Inspector
-catalog and `EventRef`, typed payloads, the late-delivery diagnostic, and the upgrade
-audit's reasoning. `Runtime/AssemblyInfo.cs` grants the test assembly access to internals so each
+`Tests/Editor` holds 150 EditMode tests across thirteen fixtures, covering dispatch
+ordering and isolation, the re-entrant publish completion contract, the static facade and
+its registration timing, all three delivery policies, the interned identity, the Inspector
+catalog and `EventRef`, typed payloads, the late-delivery diagnostic, the upgrade audit's
+reasoning, the event-domain listing, what each end of a play session drops and keeps, and
+the editor's end-of-play drop. `Runtime/AssemblyInfo.cs` grants the test assembly access to internals so each
 test can reset `EventsRegistry`'s static state — a public reset would be a footgun in
 game code.
 
@@ -822,6 +839,12 @@ Not fixed here; they are not identity or timing problems.
    Statics therefore still reset on entering play mode today, so a static registry is
    currently safe. The project is one checkbox away from statics persisting, so the
    registry resets explicitly rather than relying on that.
+   *Confirmed and amended (2.6.1):* that reading of the setting is right — measured in
+   6000.4.3f1, 6000.5.2f1 and 6000.6.0f1, batch and interactive, that combination reads
+   back as `enterPlayModeOptionsEnabled == false` and the domain reloads — but the reset
+   it justified was inverted; see *Play-session reset* under *Implemented:
+   `EventsFor<T>`*. Unity 6.6 makes domain-reload-off the default for new projects, so
+   the checkbox is now the norm rather than the exception.
 5. **Inspector call sites** — adopt a serializable `EventRef` (enum type name +
    member name) with a two-dropdown property drawer, rather than a concrete
    per-family subclass of each generic component. Keeps one component per behavior,

--- a/Editor/ClearEventsMenu.cs
+++ b/Editor/ClearEventsMenu.cs
@@ -3,29 +3,26 @@ using UnityEditor;
 namespace CrawfisSoftware.Events.Editor
 {
     /// <summary>
-    /// Menu entry points for inspecting the publisher, and the clear that runs when play mode ends.
+    /// Menu entry points for inspecting the publisher, and the end-of-session drop that runs once play
+    /// mode has finished tearing down.
     /// </summary>
     /// <remarks>
-    /// <para>The clear used to sit behind a "Clear Events on Exiting Play Mode" toggle that defaulted
-    /// off, and that never actually ran: the method wired to
-    /// <see cref="EditorApplication.playModeStateChanged"/> carried the name of the class it was copied
-    /// from, so it was an ordinary private method rather than the static constructor
-    /// <c>[InitializeOnLoad]</c> calls, and the toggle's menu item had a validator but no action, so it
-    /// could not be switched on either.</para>
-    /// <para>It is now unconditional. With <em>Enter Play Mode Options</em> set to skip the domain
-    /// reload, statics survive between play sessions, so <see cref="EventsPublisher"/> would otherwise
-    /// carry the previous session's subscriptions — delegates bound to destroyed objects — into the
-    /// next one. <c>EventsRegistry.ResetStaticState</c> already drops the rest of the package's static
-    /// state at <c>SubsystemRegistration</c>; this is the publisher's half of the same job, and doing
-    /// it unconditionally keeps it correct whatever that project setting says.</para>
+    /// <para>With <em>Enter Play Mode Options</em> set to skip the domain reload — Unity 6.6's default
+    /// for new projects — statics survive between play sessions, so <see cref="EventsPublisher"/> would
+    /// otherwise carry the previous session's subscriptions, delegates bound to destroyed objects, and
+    /// its retained values into the next one. <see cref="EventsRegistry.EndPlaySession"/> drops those
+    /// and keeps every declaration; see it for what falls on which side and why.</para>
     /// <para>It runs at <see cref="PlayModeStateChange.EnteredEditMode"/> rather than
     /// <see cref="PlayModeStateChange.ExitingPlayMode"/>, which is the point teardown has finished: an
     /// <c>OnDestroy</c> that unsubscribes, or that publishes a shutdown event, still sees the
     /// subscribers it expects. The cost is that <b>List Current Subscribers</b> reports nothing once
     /// play mode has ended — inspect a subscription leak while still in play mode.</para>
-    /// <para>This clears subscriptions, registered names and retained values on every frame of the
-    /// publisher stack. It does not unwind the stack itself: a frame pushed and never popped survives,
-    /// empty, which is harmless but is not what the code that pushed it intended.</para>
+    /// <para>History: until 2.6.0 the drop sat behind a "Clear Events on Exiting Play Mode" toggle that
+    /// never ran — the hook lived in an ordinary method named after the class it was copied from, and
+    /// the toggle's menu item had a validator but no action. 2.6.0 made it unconditional, as a full
+    /// <see cref="EventsPublisher.Clear"/>, which also discarded the registrations a static initializer
+    /// cannot make again without a domain reload; 2.6.1 keeps those, and unwinds frames pushed above
+    /// the root rather than leaving them on the stack empty.</para>
     /// </remarks>
     [InitializeOnLoad]
     public class ClearEventsMenu : EditorWindow
@@ -58,11 +55,11 @@ namespace CrawfisSoftware.Events.Editor
             UnityEngine.Debug.Log($"   ....  {count} subscribers listed");
         }
 
-        private static void OnPlayModeStateChanged(PlayModeStateChange state)
+        internal static void OnPlayModeStateChanged(PlayModeStateChange state)
         {
             if (state == PlayModeStateChange.EnteredEditMode)
             {
-                EventsPublisher.Instance.Clear();
+                EventsRegistry.EndPlaySession();
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -182,11 +182,34 @@ prints it and the system looks healthy. It also reports a publish whose payload 
 what the event declared it carries, naming the sender.
 
 **CrawfisSoftware > Events** also has *Log Events* (logs every publish while in play
-mode), *List Current Subscribers*, and *Clear Now*. Subscriptions, registered names and
-retained values are cleared automatically once play mode ends — unconditionally as of
-2.6.0, because with *Enter Play Mode Options* set to skip the domain reload the publisher
-is static state that would otherwise carry a dead session's subscribers into the next run.
-Inspect a subscription leak while still in play mode; afterwards there is nothing to list.
+mode), *List Current Subscribers*, and *Clear Now*. Subscriptions and retained values are
+dropped automatically once play mode has finished tearing down, and again on the next
+play entry; registrations and declarations stay (see the next section). Inspect a
+subscription leak while still in play mode; afterwards there is nothing to list.
+
+## Entering Play mode without domain reload
+
+Unity 6.6 creates new projects with domain reload off when entering Play mode, and
+recommends that setting everywhere. Statics then survive from one play session to the
+next, so the package resets itself at `SubsystemRegistration` on every play entry, and
+the editor does the same once play mode has finished tearing down:
+
+| Dropped at each play entry | Kept |
+|---|---|
+| subscriptions, including "all events" subscribers | event registrations |
+| Sticky values and Replay journals | delivery policies, whether from an attribute or `RegisterEvent(name, policy)` |
+| publisher frames pushed above the root | declared payload types, prefix claims, the domain listing |
+| typed-handler wrappers, `EventsDiagnostics` counts | interned `EventId`s |
+
+Runtime state belongs to a session. Declarations derive from code, and code changes
+only through a recompile, which always reloads the domain — so a policy or payload type
+declared from a static initializer stays declared even though that initializer runs
+once. With domain reload on, the reset runs against empty state and changes nothing.
+
+The end-of-play drop is the same minus the diagnostics, which the upgrade audit reads
+after play mode ends. `EventsPublisher.StrictMode` and `EventsDiagnostics.Enabled` are
+ordinary settings and are never reset. *Clear Now* is the stronger operation: it drops
+registrations too, and an annotated family is registered again by the next play entry.
 
 ## Upgrading an existing project
 

--- a/Runtime/EventsFor.cs
+++ b/Runtime/EventsFor.cs
@@ -44,14 +44,21 @@ namespace CrawfisSoftware.Events
         }
 
         /// <summary>
-        /// Registers every member of <typeparamref name="T"/> if that has not happened yet.
+        /// Registers every member of <typeparamref name="T"/> with the current publisher frame.
         /// </summary>
-        /// <remarks>Rarely needed directly — publishing or subscribing does this implicitly. Call it to
-        /// register the family ahead of a raw-string publish, or mark the enum with
-        /// <see cref="EventEnumAttribute"/> to have it called automatically before the first scene loads.</remarks>
+        /// <remarks>
+        /// <para>Rarely needed directly — the first publish or subscribe through this type registers the
+        /// family. Call it to register the family ahead of a raw-string publish, or mark the enum with
+        /// <see cref="EventEnumAttribute"/> to have it called automatically before the first scene
+        /// loads.</para>
+        /// <para>Idempotent, and it registers on every call rather than only on the one that builds the
+        /// facade, so the <see cref="EventEnumAttribute"/> sweep restores a family's registrations after
+        /// an explicit <c>Clear()</c> — the editor's "Clear Now" and "Clear Events on Exiting Play
+        /// Mode" — even though the facade is cached.</para>
+        /// </remarks>
         public static void EnsureRegistered()
         {
-            _ = Facade;
+            Facade.RegisterKnownEvents();
         }
 
         private static void Reset()

--- a/Runtime/EventsPublisher.cs
+++ b/Runtime/EventsPublisher.cs
@@ -36,6 +36,28 @@ namespace CrawfisSoftware.Events
 
         private readonly Stack<IEventsPublisher<string>> _eventsPublishers = new Stack<IEventsPublisher<string>>();
 
+        internal int FrameCount => _eventsPublishers.Count;
+
+        /// <summary>
+        /// Discards the previous play session's runtime state: every frame pushed above the root, and
+        /// the root frame's subscriptions and retained values. Registrations survive.
+        /// </summary>
+        /// <remarks>Called by <see cref="EventsRegistry.EndPlaySession"/> once play mode has torn down. A frame
+        /// pushed for a scene that was never popped — because play mode ended first — would otherwise
+        /// stay on the stack, one more per play session, still holding that scene's retained
+        /// values.</remarks>
+        internal void DropSessionState()
+        {
+            while (_eventsPublishers.Count > 1) _eventsPublishers.Pop();
+            if (_eventsPublishers.Count == 0)
+            {
+                Push();
+                return;
+            }
+            if (_eventsPublishers.Peek() is EventsPublisherInternal root) root.DropSessionState();
+            else _eventsPublishers.Peek().Clear();
+        }
+
         /// <inheritdoc/>
         public void Push()
         {
@@ -183,7 +205,9 @@ namespace CrawfisSoftware.Events
         /// keeps the policy next to the event.</para>
         /// <para>Call this from a static initializer rather than from <c>Awake</c>. The policy must be
         /// declared before the event is first published, or the first publish — often the one that
-        /// matters most during boot — is not retained.</para>
+        /// matters most during boot — is not retained. A declaration made there survives entering Play
+        /// mode without a domain reload: the play-session reset keeps declarations and drops only the
+        /// previous session's runtime state.</para>
         /// <para>First explicit declaration wins; a second, differing one is reported and ignored.</para>
         /// </remarks>
         public void RegisterEvent(string eventName, EventDelivery delivery)

--- a/Runtime/EventsPublisherInternal.cs
+++ b/Runtime/EventsPublisherInternal.cs
@@ -336,6 +336,25 @@ namespace CrawfisSoftware.Events
         {
         }
 
+        /// <summary>
+        /// Drops what a play session accumulated — subscriptions, "all events" subscribers, retained
+        /// values, anything still queued — and keeps the registrations.
+        /// </summary>
+        /// <remarks>A registration is a declaration: the event exists. The keys stay so that
+        /// <see cref="EventsPublisher.StrictMode"/> still knows the name and the editor menu still lists
+        /// it; only the delegates behind them go. <see cref="Clear"/> is the stronger operation that
+        /// drops the registrations too.</remarks>
+        internal void DropSessionState()
+        {
+            var registered = new List<EventId>(events.Keys);
+            foreach (EventId eventId in registered) events[eventId] = NullCallback;
+            allSubscribers.Clear();
+            _stickyValues.Clear();
+            _journals.Clear();
+            _callbackQueue.Clear();
+            _drainDepth = 0;
+        }
+
         public void Clear()
         {
             events.Clear();

--- a/Runtime/EventsRegistry.cs
+++ b/Runtime/EventsRegistry.cs
@@ -269,23 +269,76 @@ namespace CrawfisSoftware.Events
         }
 
         /// <summary>
-        /// Clears static state carried over from a previous play session.
+        /// Starts a play session. Resets the diagnostics and nothing else.
         /// </summary>
         /// <remarks>
         /// <para>Runs at <see cref="RuntimeInitializeLoadType.SubsystemRegistration"/>, the earliest
-        /// runtime hook, so it completes before the <see cref="RuntimeInitializeLoadType.BeforeSceneLoad"/>
-        /// sweep below.</para>
-        /// <para>With domain reload enabled this is a no-op on already-empty state. It matters when
-        /// <em>Enter Play Mode Options</em> has domain reload disabled, where statics survive between
-        /// play sessions. Resetting explicitly rather than relying on that project setting keeps this
-        /// correct either way.</para>
-        /// <para>This deliberately does not clear <see cref="EventsPublisher"/> itself. Dropping live
-        /// subscriptions is a behavioral choice the project already exposes through the editor's
-        /// "Clear Events on Exiting Play Mode" toggle, and is not silently taken here.</para>
+        /// runtime hook, on every play entry. With domain reload on it finds empty state. With it off —
+        /// Unity 6.6's default for new projects — the statics carry over from the previous session,
+        /// and the question is which of them should.</para>
+        /// <para><b>Declarations</b> should: registrations, delivery policies, payload types, prefix
+        /// claims, the domain listing, the intern table. Each derives from code, and code changes only
+        /// through a recompile, which always reloads the domain. The static initializers that declared
+        /// them run once per domain and would not run again, so dropping them here silently reverted
+        /// an imperatively declared policy to Transient on the second play and switched a declared
+        /// payload type's check off — which is what 2.4.0 through 2.6.0 did.</para>
+        /// <para><b>Runtime state</b> — subscriptions, retained values, pushed frames — should not
+        /// carry over, but it is not dropped here either. Ordering among
+        /// <c>SubsystemRegistration</c> entry points is undefined, so a drop in this phase could
+        /// discard a subscription a consumer's own entry point had just made. It is dropped by
+        /// <see cref="EndPlaySession"/> instead, once the previous session has finished tearing down,
+        /// which the editor calls from <c>EditorApplication.playModeStateChanged</c>. A build starts
+        /// from a fresh process and needs neither.</para>
+        /// <para>The diagnostics are reset here rather than there because the upgrade audit reads them
+        /// after play mode ends. Cleared at the start of a session, what it reads is one boot sequence
+        /// rather than an editor session's accumulated noise.</para>
         /// </remarks>
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        internal static void BeginPlaySession()
+        {
+            EventsDiagnostics.Reset();
+        }
+
+        /// <summary>
+        /// Ends a play session: drops its runtime state and keeps every declaration.
+        /// </summary>
+        /// <remarks>
+        /// <para>Called by the editor once play mode has finished tearing down — at
+        /// <c>EnteredEditMode</c> rather than <c>ExitingPlayMode</c>, so an <c>OnDestroy</c> that
+        /// unsubscribes or publishes a shutdown event still finds the subscribers it expects.</para>
+        /// <para>What goes: subscriptions and "all events" subscribers, Sticky values and Replay
+        /// journals, frames pushed above the root, and the typed-handler wrapper table, which mirrors
+        /// the subscriptions and goes with them. Each describes objects and publishes of the session
+        /// that just ended: a subscription that outlived its session targets a destroyed object or
+        /// duplicates the one its replacement will make, and a retained value would be replayed to the
+        /// next session's subscribers with a sender that no longer exists.</para>
+        /// <para>What stays: every declaration, for the reasons given on
+        /// <see cref="BeginPlaySession"/>, and the diagnostics, which the audit reads after this
+        /// point. <see cref="EventsPublisher.Clear"/> is the stronger operation behind the editor's
+        /// <b>Clear Now</b>; it drops registrations too.</para>
+        /// </remarks>
+        internal static void EndPlaySession()
+        {
+            ((EventsPublisher)EventsPublisher.Instance).DropSessionState();
+            TypedSubscriptions.Clear();
+        }
+
+        /// <summary>
+        /// Test isolation only: drops declarations and runtime state alike, so each test starts from
+        /// nothing.
+        /// </summary>
+        /// <remarks>
+        /// <para>Not a runtime hook, and must not become one. Wired to play entry it would be the bug
+        /// <see cref="BeginPlaySession"/> describes.</para>
+        /// <para>The intern table is deliberately not cleared even here. Handles are values that callers
+        /// may still hold; recycling them would silently repoint an <see cref="EventId"/> at a different
+        /// event. It is bounded by the number of distinct event names in the project, so letting it
+        /// persist costs nothing.</para>
+        /// </remarks>
         internal static void ResetStaticState()
         {
+            EndPlaySession();
+            BeginPlaySession();
             for (int i = 0; i < _resetHandlers.Count; i++)
             {
                 try { _resetHandlers[i](); }
@@ -298,14 +351,6 @@ namespace CrawfisSoftware.Events
             _registeredEnums.Clear();
             _policies.Clear();
             _payloadTypes.Clear();
-            TypedSubscriptions.Clear();
-            // Cleared at the start of a play session, not the end, so what the audit reads afterwards is
-            // one boot sequence rather than an editor session's accumulated noise.
-            EventsDiagnostics.Reset();
-            // The intern table is deliberately NOT cleared. Handles are values that callers may still
-            // hold; recycling them would silently repoint an EventId at a different event. It is bounded
-            // by the number of distinct event names in the project, so letting it persist costs nothing.
-
         }
 
         /// <summary>

--- a/Runtime/IEventsPublisher.cs
+++ b/Runtime/IEventsPublisher.cs
@@ -42,8 +42,10 @@ namespace CrawfisSoftware.Events
         /// <remarks>The escape hatch for names no enum can annotate — runtime-computed names and
         /// Inspector-authored strings. For an enum family, prefer <see cref="EventDeliveryAttribute"/>
         /// on the member. Declare from a static initializer rather than <c>Awake</c>: the policy must
-        /// be in place before the event is first published, or that first publish is not retained.
-        /// First declaration wins; a differing second one is reported and ignored.</remarks>
+        /// be in place before the event is first published, or that first publish is not retained. A
+        /// declaration survives entering Play mode without a domain reload, which drops only the
+        /// previous session's runtime state. First declaration wins; a differing second one is reported
+        /// and ignored.</remarks>
         void RegisterEvent(T eventName, EventDelivery delivery);
 
         /// <summary>

--- a/Tests/Editor/ClearEventsMenuTests.cs
+++ b/Tests/Editor/ClearEventsMenuTests.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+
+using CrawfisSoftware.Events.Editor;
+
+using NUnit.Framework;
+
+using UnityEditor;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    /// <summary>
+    /// The clear the editor performs when play mode has finished tearing down.
+    /// </summary>
+    /// <remarks>2.6.0 made it unconditional after finding that the toggle guarding it had never been
+    /// wired. It cleared everything, registrations included, which a static initializer cannot put back
+    /// without a domain reload. It now drops the session's runtime state and keeps the declarations,
+    /// the same rule the play-entry reset follows.</remarks>
+    public class ClearEventsMenuTests : EventsTestBase
+    {
+        [Test]
+        public void TheHook_IsInstalledByAStaticConstructor()
+        {
+            // [InitializeOnLoad] runs the static constructor and nothing else. Until 2.6.0 the hook sat
+            // in an ordinary method named EventLoggingMenu, which nothing called.
+            Assert.IsNotNull(typeof(ClearEventsMenu).TypeInitializer);
+        }
+
+        [Test]
+        public void EnteredEditMode_DropsSubscriptionsAndRetainedValues()
+        {
+            Bus.RegisterEvent("Menu/Sticky", EventDelivery.Sticky);
+            Bus.SubscribeToEvent("Menu/Sticky", Recorder("stale"));
+            Bus.PublishEvent("Menu/Sticky", null, "old");
+            Log.Clear();
+
+            ClearEventsMenu.OnPlayModeStateChanged(PlayModeStateChange.EnteredEditMode);
+
+            Assert.IsFalse(Bus.TryGetLast("Menu/Sticky", out _, out _));
+            Bus.PublishEvent("Menu/Sticky", null, "new");
+            Assert.AreEqual("", string.Join(",", Log));
+        }
+
+        [Test]
+        public void EnteredEditMode_KeepsRegistrations()
+        {
+            Bus.RegisterEvent("Menu/Registered");
+
+            ClearEventsMenu.OnPlayModeStateChanged(PlayModeStateChange.EnteredEditMode);
+
+            CollectionAssert.Contains(Bus.GetRegisteredEvents().ToList(), "Menu/Registered");
+        }
+
+        [Test]
+        public void EnteredEditMode_KeepsTheDiagnostics()
+        {
+            // The upgrade audit is refreshed after play mode ends; clearing here would blank it.
+            EventsFor<SessionTestEvents>.Publish(SessionTestEvents.Edge, null, null);
+            EventsFor<SessionTestEvents>.Subscribe(SessionTestEvents.Edge, Recorder("late"));
+
+            ClearEventsMenu.OnPlayModeStateChanged(PlayModeStateChange.EnteredEditMode);
+
+            Assert.AreEqual(1, EventsDiagnostics.GetLateDeliveries().Count);
+        }
+
+        [Test]
+        public void ExitingPlayMode_LeavesEverythingInPlace()
+        {
+            // Teardown runs between ExitingPlayMode and EnteredEditMode. An OnDestroy that publishes a
+            // shutdown event, or unsubscribes, must still find the subscribers it expects.
+            Bus.SubscribeToEvent("Menu/Shutdown", Recorder("teardown"));
+
+            ClearEventsMenu.OnPlayModeStateChanged(PlayModeStateChange.ExitingPlayMode);
+            Bus.PublishEvent("Menu/Shutdown", null, "bye");
+
+            Assert.AreEqual("teardown:bye", string.Join(",", Log));
+        }
+    }
+}

--- a/Tests/Editor/ClearEventsMenuTests.cs.meta
+++ b/Tests/Editor/ClearEventsMenuTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fdba2bb0945bd2e4eb6569b1b662f1c3

--- a/Tests/Editor/EventPayloadTests.cs
+++ b/Tests/Editor/EventPayloadTests.cs
@@ -134,19 +134,21 @@ namespace CrawfisSoftware.Events.Tests
         }
 
         [Test]
-        public void Reset_DropsTheWrapperTable()
+        public void Reset_DropsTheWrapperTableTogetherWithTheSubscription()
         {
             Detailed.Subscribe(OnDetailed);
             EventsRegistry.ResetStaticState();
 
-            // The publisher's subscriptions are deliberately not cleared by a reset, so a leaked wrapper
-            // entry would survive here and a later Unsubscribe would remove a handler belonging to the
-            // previous play session.
+            // The wrapper table mirrors the publisher's subscriptions, so a reset has to drop both or
+            // neither. 2.4.1 dropped only the table: the old subscription stayed live, a re-subscribe
+            // added a second one, and the one Unsubscribe that followed could remove only one of them.
             Detailed.Unsubscribe(OnDetailed);
             Detailed.Publish(null, new PayloadData { Value = 5 });
+            Assert.AreEqual("", string.Join(",", Log), "nothing from before the reset may still be subscribed");
 
-            Assert.AreEqual("detailed:5", string.Join(",", Log),
-                "reset must forget the wrapper, leaving the old subscription for Clear() to deal with");
+            Detailed.Subscribe(OnDetailed);
+            Detailed.Publish(null, new PayloadData { Value = 6 });
+            Assert.AreEqual("detailed:6", string.Join(",", Log), "a fresh subscribe after the reset delivers exactly once");
         }
 
         // ---- retained values ----

--- a/Tests/Editor/PlaySessionResetTests.cs
+++ b/Tests/Editor/PlaySessionResetTests.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+using NUnit.Framework;
+
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace CrawfisSoftware.Events.Tests
+{
+    [EventEnum]
+    public enum SessionTestEvents
+    {
+        [EventDelivery(EventDelivery.Sticky)] Level,
+        [EventDelivery(EventDelivery.Replay)] Journal,
+        Edge,
+    }
+
+    /// <summary>
+    /// What survives from one play session to the next when the domain is not reloaded, and what
+    /// does not.
+    /// </summary>
+    /// <remarks>
+    /// <para>Two hooks bracket a session. Unity calls <see cref="EventsRegistry.BeginPlaySession"/> at
+    /// <see cref="RuntimeInitializeLoadType.SubsystemRegistration"/> on every play entry; the editor
+    /// calls <see cref="EventsRegistry.EndPlaySession"/> once play mode has finished tearing down.
+    /// With domain reload on both run against empty statics. With it off — Unity 6.6's default for
+    /// new projects — the statics carry over, and these two are what separate one session from the
+    /// next.</para>
+    /// <para>The rule they implement: <em>runtime state</em> belongs to a session and is dropped at
+    /// its end — subscriptions, retained values, pushed frames, typed wrappers. <em>Declarations</em>
+    /// derive from code and are kept at both ends — registrations, delivery policies, payload types,
+    /// prefix claims, the domain listing, interned ids. A declaration can only change through a
+    /// recompile, which always reloads the domain, and the static initializers that made it will not
+    /// run again without one. The play-entry hook resets the diagnostics and nothing else: ordering
+    /// within <c>SubsystemRegistration</c> is undefined, so a drop there could discard a subscription a
+    /// consumer's own entry point had just made.</para>
+    /// <para>2.4.0 through 2.6.0 wiped the declarations at play entry and, from 2.6.0, the
+    /// registrations at play exit.</para>
+    /// </remarks>
+    public class PlaySessionResetTests : EventsTestBase
+    {
+        private static EventsPublisher Publisher => (EventsPublisher)EventsPublisher.Instance;
+
+        // ---- the hooks themselves ----
+
+        [Test]
+        public void BeginPlaySession_IsTheSubsystemRegistrationHook()
+        {
+            MethodInfo hook = typeof(EventsRegistry).GetMethod(
+                nameof(EventsRegistry.BeginPlaySession), BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+            var attribute = hook.GetCustomAttribute<RuntimeInitializeOnLoadMethodAttribute>();
+
+            Assert.IsNotNull(attribute, "the session start must run on every play entry");
+            Assert.AreEqual(RuntimeInitializeLoadType.SubsystemRegistration, attribute.loadType,
+                "it must precede the BeforeSceneLoad sweep and every Awake");
+        }
+
+        [Test]
+        public void TheFullReset_IsNotARuntimeHook()
+        {
+            // ResetStaticState wipes declarations too. It exists for test isolation; wired to play entry
+            // it would silently revert every policy a static initializer declared, which is the bug.
+            MethodInfo fullReset = typeof(EventsRegistry).GetMethod(
+                nameof(EventsRegistry.ResetStaticState), BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+            Assert.IsNull(fullReset.GetCustomAttribute<RuntimeInitializeOnLoadMethodAttribute>());
+        }
+
+        // ---- play entry: diagnostics reset, everything else untouched ----
+
+        [Test]
+        public void BeginPlaySession_ResetsTheDiagnostics()
+        {
+            // The audit reads one boot sequence, not an editor session's accumulated noise.
+            EventsFor<SessionTestEvents>.Publish(SessionTestEvents.Edge, null, null);
+
+            EventsRegistry.BeginPlaySession();
+            EventsFor<SessionTestEvents>.Subscribe(SessionTestEvents.Edge, Recorder("x"));
+
+            Assert.AreEqual(0, EventsDiagnostics.GetLateDeliveries().Count);
+        }
+
+        [Test]
+        public void BeginPlaySession_KeepsSubscriptionsAndRetainedValues()
+        {
+            // Ordering among SubsystemRegistration entry points is undefined. A consumer's own entry
+            // point may subscribe before this one runs, and that subscription must survive. Runtime
+            // state is dropped at the end of the previous session instead.
+            Bus.RegisterEvent("Session/Early", EventDelivery.Sticky);
+            Bus.SubscribeToEvent("Session/Early", Recorder("early"));
+            Bus.PublishEvent("Session/Early", null, "v");
+            Log.Clear();
+
+            EventsRegistry.BeginPlaySession();
+
+            Assert.IsTrue(Bus.TryGetLast("Session/Early", out _, out _));
+            Bus.PublishEvent("Session/Early", null, "w");
+            Assert.AreEqual("early:w", string.Join(",", Log));
+        }
+
+        [Test]
+        public void Registrations_Survive_SoStrictModeStaysQuiet()
+        {
+            Bus.RegisterEvent("Session/Registered");
+
+            EventsRegistry.BeginPlaySession();
+            Bus.PublishEvent("Session/Registered", "probe", null);
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void PolicyDeclaredImperatively_Survives()
+        {
+            // The documented home for RegisterEvent(name, policy) is a static initializer, which runs
+            // once per domain. Dropping the policy here would revert the event to Transient on the second
+            // play, silently, with nothing left to re-declare it.
+            Bus.RegisterEvent("Session/Sticky", EventDelivery.Sticky);
+
+            EventsRegistry.BeginPlaySession();
+            Bus.PublishEvent("Session/Sticky", null, "v");
+            Bus.SubscribeToEvent("Session/Sticky", Recorder("late"));
+
+            Assert.AreEqual("late:v", string.Join(",", Log));
+        }
+
+        [Test]
+        public void PolicyDeclaredByAttribute_Survives()
+        {
+            EventsFor<SessionTestEvents>.EnsureRegistered();
+
+            EventsRegistry.BeginPlaySession();
+            EventsFor<SessionTestEvents>.Publish(SessionTestEvents.Level, null, "v");
+            EventsFor<SessionTestEvents>.Subscribe(SessionTestEvents.Level, Recorder("late"));
+
+            Assert.AreEqual("late:v", string.Join(",", Log));
+        }
+
+        [Test]
+        public void PayloadDeclaration_Survives_SoStrictModeStillChecksIt()
+        {
+            // Declared in a static readonly field, per the README. Forgetting it on the second play turns
+            // the payload check off for that event with no message anywhere.
+            EventId<string> typed = EventId<string>.Of("Session/Typed");
+            typed.Register();
+
+            EventsRegistry.BeginPlaySession();
+
+            LogAssert.Expect(LogType.Error, new Regex("Session/Typed.*declared to carry System.String"));
+            Bus.PublishEvent("Session/Typed", "probe", 12345);
+        }
+
+        [Test]
+        public void PrefixClaims_Survive_SoACollisionIsStillReported()
+        {
+            EventsFor<CollidingA.SameNameEvents>.EnsureRegistered();
+
+            EventsRegistry.BeginPlaySession();
+
+            LogAssert.Expect(LogType.Error, new Regex("both project onto the event name prefix 'SameNameEvents/'"));
+            EventsFor<CollidingB.SameNameEvents>.EnsureRegistered();
+        }
+
+        [Test]
+        public void RegisteredEnumTypes_Survive()
+        {
+            // The domain listing describes the code, not the session.
+            EventsFor<SessionTestEvents>.EnsureRegistered();
+
+            EventsRegistry.BeginPlaySession();
+
+            CollectionAssert.Contains(EventsRegistry.RegisteredEnumTypes, typeof(SessionTestEvents));
+        }
+
+        [Test]
+        public void BeginPlaySession_IsIdempotent()
+        {
+            Bus.RegisterEvent("Session/Twice", EventDelivery.Sticky);
+
+            EventsRegistry.BeginPlaySession();
+            EventsRegistry.BeginPlaySession();
+            Bus.PublishEvent("Session/Twice", null, "v");
+            Bus.SubscribeToEvent("Session/Twice", Recorder("late"));
+
+            Assert.AreEqual("late:v", string.Join(",", Log));
+        }
+
+        // ---- play end: runtime state dropped, declarations and diagnostics kept ----
+
+        [Test]
+        public void EndPlaySession_DropsSubscriptions()
+        {
+            // A subscriber that outlived its session targets a destroyed object, or duplicates the
+            // subscription its replacement is about to make. Neither is ever wanted.
+            Bus.SubscribeToEvent("Session/A", Recorder("stale"));
+            Bus.SubscribeToAllEvents(Recorder("stale-all"));
+
+            EventsRegistry.EndPlaySession();
+            Bus.PublishEvent("Session/A", null, "v");
+
+            Assert.AreEqual("", string.Join(",", Log));
+        }
+
+        [Test]
+        public void EndPlaySession_DropsTheStickyValue()
+        {
+            EventsFor<SessionTestEvents>.Publish(SessionTestEvents.Level, null, "old");
+
+            EventsRegistry.EndPlaySession();
+
+            Assert.IsFalse(EventsFor<SessionTestEvents>.TryGetLast(SessionTestEvents.Level, out _, out _));
+            EventsFor<SessionTestEvents>.Subscribe(SessionTestEvents.Level, Recorder("late"));
+            Assert.AreEqual("", string.Join(",", Log),
+                "the next session's subscriber must not be handed this session's value");
+        }
+
+        [Test]
+        public void EndPlaySession_DropsTheReplayJournal()
+        {
+            EventsFor<SessionTestEvents>.Publish(SessionTestEvents.Journal, null, "old");
+
+            EventsRegistry.EndPlaySession();
+            EventsFor<SessionTestEvents>.Subscribe(SessionTestEvents.Journal, Recorder("late"));
+
+            Assert.AreEqual("", string.Join(",", Log));
+        }
+
+        [Test]
+        public void EndPlaySession_PopsPushedFrames()
+        {
+            // A frame pushed for a scene and never popped, because play mode ended first, would
+            // otherwise stay on the stack — one more per session — still holding that scene's values.
+            Bus.Push();
+            Bus.Push();
+
+            EventsRegistry.EndPlaySession();
+
+            Assert.AreEqual(1, Publisher.FrameCount);
+        }
+
+        [Test]
+        public void EndPlaySession_ForgetsTypedWrappersTogetherWithTheirSubscriptions()
+        {
+            // The wrapper table mirrors the publisher's subscriptions. Dropping one without the other
+            // leaves a handler that re-subscribes next session subscribed twice, or unable to unsubscribe.
+            EventId<string> typed = EventId<string>.Of("Session/TypedSub");
+            typed.Register();
+            Action<string, object, string> handler = (e, s, d) => Log.Add("typed:" + d);
+            typed.Subscribe(handler);
+
+            EventsRegistry.EndPlaySession();
+            typed.Subscribe(handler);
+            typed.Publish(null, "v");
+            Assert.AreEqual("typed:v", string.Join(",", Log), "delivered once, not once per session");
+
+            Log.Clear();
+            typed.Unsubscribe(handler);
+            typed.Publish(null, "w");
+            Assert.AreEqual("", string.Join(",", Log), "one unsubscribe must remove the only subscription");
+        }
+
+        [Test]
+        public void EndPlaySession_KeepsRegistrationsAndPolicies()
+        {
+            // A registration made from a static initializer cannot be made again without a domain
+            // reload, so dropping it here would have StrictMode report the event on the next play.
+            Bus.RegisterEvent("Session/EndKeep", EventDelivery.Sticky);
+
+            EventsRegistry.EndPlaySession();
+            Bus.PublishEvent("Session/EndKeep", "probe", "v");
+            Bus.SubscribeToEvent("Session/EndKeep", Recorder("late"));
+
+            Assert.AreEqual("late:v", string.Join(",", Log));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void EndPlaySession_KeepsTheDiagnostics()
+        {
+            // The upgrade audit reads them after play mode has ended; that is its whole workflow.
+            EventsFor<SessionTestEvents>.Publish(SessionTestEvents.Edge, null, null);
+            EventsFor<SessionTestEvents>.Subscribe(SessionTestEvents.Edge, Recorder("late"));
+
+            EventsRegistry.EndPlaySession();
+
+            Assert.AreEqual(1, EventsDiagnostics.GetLateDeliveries().Count);
+        }
+
+        [Test]
+        public void EndPlaySession_IsIdempotent()
+        {
+            Bus.RegisterEvent("Session/EndTwice", EventDelivery.Sticky);
+            Bus.Push();
+
+            EventsRegistry.EndPlaySession();
+            EventsRegistry.EndPlaySession();
+            Bus.PublishEvent("Session/EndTwice", null, "v");
+            Bus.SubscribeToEvent("Session/EndTwice", Recorder("late"));
+
+            Assert.AreEqual("late:v", string.Join(",", Log));
+            Assert.AreEqual(1, Publisher.FrameCount);
+        }
+
+        // ---- the sweep after an explicit Clear ----
+
+        [Test]
+        public void AnnotatedFamily_IsReRegisteredByTheSweepAfterAClear()
+        {
+            // The editor's "Clear Now" drops registrations. The BeforeSceneLoad sweep must put an
+            // annotated family's back even though its facade is cached, or the first publish of the
+            // next session is reported as unregistered.
+            EventsFor<SessionTestEvents>.EnsureRegistered();
+            Bus.Clear();
+
+            EventsRegistry.RegisterAnnotatedEventEnums(OwnAssembly);
+            EventsFor<SessionTestEvents>.Publish(SessionTestEvents.Edge, "probe", null);
+
+            LogAssert.NoUnexpectedReceived();
+        }
+    }
+}

--- a/Tests/Editor/PlaySessionResetTests.cs.meta
+++ b/Tests/Editor/PlaySessionResetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 13fb95e004884a040be80899dedb4170

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.crawfissoftware.eventspublisher",
   "displayName": "Events Publisher",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "unity": "2022.3",
   "description": "Lightweight, allocation-safe event/messaging publisher for Unity projects. Editor tooling included.",
   "keywords": [ "events", "messaging", "publisher", "observer", "csharp", "unity" ],


### PR DESCRIPTION
## Why

With *Enter Play Mode Options* skipping the domain reload — Unity 6.6's default for new projects — the `SubsystemRegistration` hook wiped every **declaration** (delivery policies, payload types, prefix claims, the domain listing) while the static initializers that made them never ran again. From the second play on:

- a policy declared with `RegisterEvent(name, policy)` silently reverted to `Transient`;
- a payload declared with `EventId<T>.Of` silently stopped being checked;
- `EventsRegistry.RegisteredEnumTypes` forgot every family until touched again;
- and 2.6.0's full `Clear()` at `EnteredEditMode` dropped registrations too, so StrictMode reported imperatively registered events as unregistered.

Reproduced with a two-play-session probe in Unity 6000.6.0f1 with `DisableDomainReload` set (session 2: policy `Transient`, payload `null`, wrong-payload publish unreported).

## What

The rule is the same at both ends of a session:

| Dropped once play mode has torn down (`EventsRegistry.EndPlaySession`, editor) | Kept |
|---|---|
| subscriptions, "all events" subscribers | registrations |
| Sticky values, Replay journals | delivery policies (attribute or imperative) |
| frames pushed above the root | payload types, prefix claims, domain listing |
| typed-handler wrappers | interned ids, diagnostics |

`EventsRegistry.BeginPlaySession` (the `SubsystemRegistration` hook) now resets the diagnostics and nothing else. It no longer touches the publisher, so — per the ordering argument already in ADR 0001 — it cannot discard a subscription a consumer's own `SubsystemRegistration` entry point just made. `ResetStaticState` is now test-only and pinned as not being a runtime hook.

`EventsFor<T>.EnsureRegistered()` registers on every call, so the `[EventEnum]` sweep restores a family after *Clear Now*.

**Deviation from 2.6.0 to note:** the `EnteredEditMode` drop keeps registrations (2.6.0 cleared them) and unwinds frames pushed above the root (2.6.0 left them on the stack, empty).

## Evidence

- EditMode suite: **150/150** in Unity 6000.4.3f1 (`PlaySessionResetTests` ×20, `ClearEventsMenuTests` ×5 added). Both fixtures were written first and watched fail — 19 assertion failures on the 2.6.0 base with compile-only stubs — before the code was written.
- Two-session probe in Unity 6000.6.0f1 with domain reload off, against this branch: session 2 keeps every declaration, reports the wrong-payload publish, and carries over no subscribers, no Sticky value, no Replay entry.

## Version

This was requested as 2.4.2 from a clone whose `main` was still at 2.4.1. `origin/main` is at 2.6.0 (PRs #5–#7 shipped from elsewhere), so the branch is built on 2.6.0 and versioned **2.6.1**. Not merged or tagged yet, pending confirmation of that number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183sPo9qKxfnfxXwA53raZ9
