### PR TITLE
Name a throwing handler by its method and render senders defensively; release 2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.2] - 2026-09-06
+
+### Fixed
+
+- A handler that throws is reported by its method — `Namespace.Type.Method` — rather than by
+  its target's `ToString()`. A destroyed `MonoBehaviour` answers `ToString()` with `"null"`,
+  so the report for the most common case, a handler left subscribed on an object that no
+  longer exists, read "Exception publishing X to null" and named nothing. It now reads
+  "Exception publishing X to Game.Player.OnDied (destroyed)".
+- The StrictMode reports — unregistered name, mismatched payload — formatted the sender with
+  string interpolation outside any guard, so a sender whose `ToString()` throws escaped
+  `PublishEvent` itself, out of the publisher's own code and into the caller's. The sender is
+  now described defensively: `null` reads as `null` rather than as nothing, a destroyed Unity
+  object is marked as such, and a throwing `ToString()` falls back to the type name and says
+  what was thrown.
+
+### Added
+
+- Five tests in `EventsPublisherTests` pinning the report wording, bringing the suite to 155.
+
 ## [2.6.1] - 2026-09-06
 
 ### Fixed
@@ -275,6 +295,7 @@ wrong.
 
 - Initial package layout: assembly definitions, editor tooling, event subscriber logging.
 
+[2.6.2]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.6.2
 [2.6.1]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.6.1
 [2.6.0]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.6.0
 [2.5.1]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.5.1

--- a/Runtime/Describe.cs
+++ b/Runtime/Describe.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace CrawfisSoftware.Events
+{
+    /// <summary>
+    /// Renders senders and handlers for the publisher's reports without trusting their
+    /// <c>ToString</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>Two things go wrong when a report calls <c>ToString</c> on whatever it was handed. A
+    /// destroyed Unity object answers with <c>"null"</c>, so the most common exception report — a
+    /// handler left subscribed on an object that no longer exists — read "Exception publishing X to
+    /// null" and named nothing. And the StrictMode reports format the sender outside any guard, so a
+    /// <c>ToString</c> that throws — an object caught mid-teardown, say — escaped
+    /// <c>PublishEvent</c> into the caller's code.</para>
+    /// <para>A handler is therefore named by its method, which is what the reader has to go and
+    /// find, and a sender is rendered inside a guard with the type name as the fallback.</para>
+    /// </remarks>
+    internal static class Describe
+    {
+        /// <summary>
+        /// Names a handler as <c>Namespace.Type.Method</c>, marking a target that is a destroyed
+        /// Unity object.
+        /// </summary>
+        internal static string Handler(Delegate handler)
+        {
+            if (handler == null) return "null";
+
+            Type declaringType = handler.Method.DeclaringType;
+            string name = declaringType == null
+                ? handler.Method.Name
+                : declaringType.FullName + "." + handler.Method.Name;
+            return IsDestroyed(handler.Target) ? name + " (destroyed)" : name;
+        }
+
+        /// <summary>
+        /// Renders a sender, surviving a null, a destroyed Unity object, and a throwing
+        /// <c>ToString</c>.
+        /// </summary>
+        internal static string Sender(object sender)
+        {
+            if (sender == null) return "null";
+            if (IsDestroyed(sender)) return sender.GetType().FullName + " (destroyed)";
+            try
+            {
+                string text = sender.ToString();
+                return string.IsNullOrEmpty(text) ? sender.GetType().FullName : text;
+            }
+            catch (Exception e)
+            {
+                return sender.GetType().FullName + " (ToString threw " + e.GetType().Name + ")";
+            }
+        }
+
+        // Unity's overloaded == is what tells a destroyed object from a live one. The C# reference is
+        // never null for a destroyed object, which is exactly why its ToString misleads.
+        private static bool IsDestroyed(object candidate)
+        {
+            return candidate is UnityEngine.Object unityObject && unityObject == null;
+        }
+    }
+}

--- a/Runtime/Describe.cs.meta
+++ b/Runtime/Describe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cfc31073be807f74cb7c63fb12a38412

--- a/Runtime/EventsPublisher.cs
+++ b/Runtime/EventsPublisher.cs
@@ -152,7 +152,7 @@ namespace CrawfisSoftware.Events
         {
             if (string.IsNullOrEmpty(eventName))
             {
-                UnityEngine.Debug.LogError($"EventsPublisher: published a null or empty event name from {sender}.");
+                UnityEngine.Debug.LogError($"EventsPublisher: published a null or empty event name from {Describe.Sender(sender)}.");
                 return;
             }
             foreach (IEventsPublisher<string> publisher in _eventsPublishers)
@@ -161,7 +161,7 @@ namespace CrawfisSoftware.Events
                     return;
             }
             UnityEngine.Debug.LogError(
-                $"EventsPublisher: '{eventName}' was published by {sender} but is not registered, so no subscriber will receive it. " +
+                $"EventsPublisher: '{eventName}' was published by {Describe.Sender(sender)} but is not registered, so no subscriber will receive it. " +
                 "Check for a misspelled event name. Set EventsPublisher.StrictMode = false to silence this.");
         }
 
@@ -184,7 +184,7 @@ namespace CrawfisSoftware.Events
 
             string actual = data == null ? "null" : data.GetType().FullName;
             UnityEngine.Debug.LogError(
-                $"EventsPublisher: '{eventName}' was published by {sender} with a payload of {actual}, but it is " +
+                $"EventsPublisher: '{eventName}' was published by {Describe.Sender(sender)} with a payload of {actual}, but it is " +
                 $"declared to carry {declared.FullName}. Subscribers typed to that payload will be skipped. " +
                 "Set EventsPublisher.StrictMode = false to silence this.");
         }

--- a/Runtime/EventsPublisherInternal.cs
+++ b/Runtime/EventsPublisherInternal.cs
@@ -284,14 +284,16 @@ namespace CrawfisSoftware.Events
                     {
                         try
                         {
+                            // Named by method, not by the target's ToString: a destroyed Unity object
+                            // answers ToString with "null", and that is the commonest target here.
                             UnityEngine.Debug.LogError(
-                                $"Exception publishing {message.eventName} to {callback.Target}: {e}");
+                                $"Exception publishing {message.eventName} to {Describe.Handler(callback)}: {e}");
                         }
                         catch (Exception loggingFailure)
                         {
-                            // Formatting the message runs ToString on the handler's target and on the
-                            // exception, either of which can itself throw. A log line must never abort
-                            // the drain and discard the callbacks still queued.
+                            // Formatting the message runs ToString on the exception, which can itself
+                            // throw. A log line must never abort the drain and discard the callbacks
+                            // still queued.
                             UnityEngine.Debug.LogError(
                                 $"Exception publishing {message.eventName}; the details could not be formatted " +
                                 $"({loggingFailure.GetType().Name} thrown while logging {e.GetType().Name}).");

--- a/Tests/Editor/EventsPublisherTests.cs
+++ b/Tests/Editor/EventsPublisherTests.cs
@@ -77,6 +77,81 @@ namespace CrawfisSoftware.Events.Tests
             Assert.AreEqual(1, Log.Count, "the second publish should deliver exactly once");
         }
 
+        // ---- what the reports say about who was involved ----
+
+        /// <summary>A handler target whose ToString says "null", as a destroyed Unity object's does.</summary>
+        private sealed class ToStringSaysNull
+        {
+            public void Handle(string e, object s, object d) => throw new InvalidOperationException("boom");
+            public override string ToString() => "null";
+        }
+
+        /// <summary>A sender whose ToString throws, as one caught mid-teardown can.</summary>
+        private sealed class ToStringThrows
+        {
+            public override string ToString() => throw new InvalidOperationException("no string for you");
+        }
+
+        /// <summary>A handler target that is a real Unity object, so that it can be destroyed.</summary>
+        private sealed class DestroyableTarget : ScriptableObject
+        {
+            // Touching a Unity member of a destroyed object throws MissingReferenceException.
+            public void Handle(string e, object s, object d) { _ = name; }
+        }
+
+        [Test]
+        public void ThrowingHandler_IsReportedByMethod_NotByItsTargetsToString()
+        {
+            // A destroyed MonoBehaviour's ToString returns "null", which made the report read
+            // "Exception publishing C to null" — naming nothing that could be found.
+            LogAssert.Expect(LogType.Error, new Regex(@"Exception publishing C to .*ToStringSaysNull\.Handle"));
+            Bus.RegisterEvent("C");
+            Bus.SubscribeToEvent("C", new ToStringSaysNull().Handle);
+
+            Bus.PublishEvent("C", null, null);
+        }
+
+        [Test]
+        public void ThrowingHandler_OnADestroyedObject_IsReportedAsDestroyed()
+        {
+            LogAssert.Expect(LogType.Error, new Regex(@"Exception publishing C to .*DestroyableTarget\.Handle \(destroyed\)"));
+            var target = ScriptableObject.CreateInstance<DestroyableTarget>();
+            Bus.RegisterEvent("C");
+            Bus.SubscribeToEvent("C", target.Handle);
+            UnityEngine.Object.DestroyImmediate(target);
+
+            Bus.PublishEvent("C", null, null);
+        }
+
+        [Test]
+        public void StrictMode_SurvivesASenderWhoseToStringThrows()
+        {
+            // The report is formatted outside the drain's guard, so a throwing ToString escaped
+            // PublishEvent itself, out of the publisher's own code.
+            LogAssert.Expect(LogType.Error, new Regex(@"published by .*ToStringThrows.*is not registered"));
+
+            Assert.DoesNotThrow(() => Bus.PublishEvent("GameFlowEvents/Typoo", new ToStringThrows(), null));
+        }
+
+        [Test]
+        public void PayloadMismatch_SurvivesASenderWhoseToStringThrows()
+        {
+            EventId<string> typed = EventId<string>.Of("Typed/Sender");
+            typed.Register();
+            LogAssert.Expect(LogType.Error, new Regex(@"published by .*ToStringThrows.*declared to carry System.String"));
+
+            Assert.DoesNotThrow(() => Bus.PublishEvent("Typed/Sender", new ToStringThrows(), 12345));
+        }
+
+        [Test]
+        public void ANullSender_IsReportedAsNull_NotAsNothing()
+        {
+            // String interpolation renders null as nothing: "was published by  but is not registered".
+            LogAssert.Expect(LogType.Error, new Regex(@"published by null but is not registered"));
+
+            Bus.PublishEvent("GameFlowEvents/Typoo", null, null);
+        }
+
         [Test]
         public void WrongPayloadCast_IsContainedInTheHandler()
         {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.crawfissoftware.eventspublisher",
   "displayName": "Events Publisher",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "unity": "2022.3",
   "description": "Lightweight, allocation-safe event/messaging publisher for Unity projects. Editor tooling included.",
   "keywords": [ "events", "messaging", "publisher", "observer", "csharp", "unity" ],


### PR DESCRIPTION
## What

Two report-wording fixes left over from the domain-reload audit.

- **A throwing handler is named by its method.** A destroyed `MonoBehaviour` answers `ToString()` with `"null"`, so the report for the commonest case — a handler left subscribed on an object that no longer exists — read `Exception publishing X to null`. It now reads `Exception publishing X to Game.Player.OnDied (destroyed)`.
- **Senders are rendered defensively.** The StrictMode reports interpolated `{sender}` outside any guard, so a sender whose `ToString()` throws escaped `PublishEvent` into the caller's code. `null` now reads as `null` rather than as nothing, a destroyed Unity object is marked, and a throwing `ToString()` falls back to the type name and says what was thrown.

Both go through a new internal `Describe` helper (`Runtime/Describe.cs`).

## Evidence

- Five tests added to `EventsPublisherTests`, written first and watched fail (5/5 red, each for its target reason: `to null`, `published by  but`, and an `InvalidOperationException` escaping `PublishEvent` twice).
- Full EditMode suite: **155/155** in Unity 6000.4.3f1.

Versioned 2.6.2. Not merged or tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183sPo9qKxfnfxXwA53raZ9
