### PR TITLE
Add a general singleton and static-state prompt for fast Play mode; release 2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.3] - 2026-09-06
+
+Documentation only; no code change.
+
+### Added
+
+- `Documentation~/fast-play-mode-prompt.md` — a project-agnostic prompt for making a
+  consuming project's *own* static state correct when Play mode is entered without a domain
+  reload, Unity 6.6's default for new projects. It complements `upgrade-prompt.md`: that one
+  moves the event calls off `EventsPublisherEnumsSingleton<T>`; this one classifies every
+  static as a declaration to keep or runtime state to reset, gives the fix per kind
+  (singleton `Instance`, `bool` mirrors, static events, bootstrap guards, publisher frames,
+  assets loaded during play), and ends with the two-play verification the package itself was
+  checked with. Linked from the README and UPGRADING.
+
 ## [2.6.2] - 2026-09-06
 
 ### Fixed
@@ -295,6 +310,7 @@ wrong.
 
 - Initial package layout: assembly definitions, editor tooling, event subscriber logging.
 
+[2.6.3]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.6.3
 [2.6.2]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.6.2
 [2.6.1]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.6.1
 [2.6.0]: https://github.com/crawfis/EventsPublisher/releases/tag/v2.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,15 @@ Documentation only; no code change.
 
 ### Added
 
-- `Documentation~/fast-play-mode-prompt.md` — a project-agnostic prompt for making a
-  consuming project's *own* static state correct when Play mode is entered without a domain
-  reload, Unity 6.6's default for new projects. It complements `upgrade-prompt.md`: that one
-  moves the event calls off `EventsPublisherEnumsSingleton<T>`; this one classifies every
-  static as a declaration to keep or runtime state to reset, gives the fix per kind
-  (singleton `Instance`, `bool` mirrors, static events, bootstrap guards, publisher frames,
-  assets loaded during play), and ends with the two-play verification the package itself was
-  checked with. Linked from the README and UPGRADING.
+- `Documentation~/fast-play-mode-prompt.md` — a general prompt, not specific to this
+  package, for the singletons and static state in a Unity project itself when Play mode is
+  entered without a domain reload, Unity 6.6's default for new projects. It classifies every
+  static as a declaration to keep or runtime state to reset; catalogues the singleton shapes
+  — a `MonoBehaviour` with a static `Instance`, a static blackboard class, a `GameState` of
+  static bools, static events, lazily created singletons, `ScriptableObject` singletons,
+  bootstrap guards, loaded-asset handles — with the fix for each; gives an order of
+  preference for moving away from singletons altogether; and ends with the two-play
+  verification this package was checked with. Linked from the README and UPGRADING.
 
 ## [2.6.2] - 2026-09-06
 

--- a/Documentation~/UPGRADING.md
+++ b/Documentation~/UPGRADING.md
@@ -232,8 +232,9 @@ in a project that still has raw-string publishes** — which most do, and will k
   reverted to `Transient` on the second play, a payload declared with `EventId<T>.Of`
   stopped being checked, and until 2.6.0 the previous run's Sticky values leaked into the
   next; see the README section *Entering Play mode without domain reload*. The project's
-  own statics are a separate job: `fast-play-mode-prompt.md` in this folder walks an
-  assistant through finding, classifying and resetting them.
+  own singletons and statics are a separate job: `fast-play-mode-prompt.md` in this folder
+  is a general prompt, not specific to this package, for finding, classifying and replacing
+  them.
 
 ## Turning the diagnostic off
 

--- a/Documentation~/UPGRADING.md
+++ b/Documentation~/UPGRADING.md
@@ -231,7 +231,9 @@ in a project that still has raw-string publishes** — which most do, and will k
   through 2.6.0 with that setting, a policy declared with `RegisterEvent(name, policy)`
   reverted to `Transient` on the second play, a payload declared with `EventId<T>.Of`
   stopped being checked, and until 2.6.0 the previous run's Sticky values leaked into the
-  next; see the README section *Entering Play mode without domain reload*.
+  next; see the README section *Entering Play mode without domain reload*. The project's
+  own statics are a separate job: `fast-play-mode-prompt.md` in this folder walks an
+  assistant through finding, classifying and resetting them.
 
 ## Turning the diagnostic off
 

--- a/Documentation~/fast-play-mode-prompt.md
+++ b/Documentation~/fast-play-mode-prompt.md
@@ -1,137 +1,167 @@
-# Fast Enter Play Mode prompt
+# Singletons and static state under fast Play mode
 
-Drop this into an AI coding assistant working in a project that consumes EventsPublisher
-2.6.1 or later and is moving off `EventsPublisherEnumsSingleton<T>` — or off any
-`MonoBehaviour` singleton — while Unity 6.6 makes entering Play mode without a domain reload
-the default. It complements `upgrade-prompt.md`: that one migrates the event calls; this one
-makes the project's **own** static state correct when a play session starts with the
-previous session's statics still in memory.
+Drop this into an AI coding assistant working in **any** Unity project that still has
+singletons — a `MonoBehaviour` with a static `Instance`, a static blackboard class, a
+`GameState` full of static bools, static events — and that will run, or already runs, with
+Unity 6.6's default of entering Play mode without a domain reload. It is not about any
+particular package. It says what breaks, how to find every static that will break, what to
+replace each shape with, and how to prove the result with two plays.
 
-Two facts to know before pasting it. First, existing projects created before 6.6 still carry
-the old setting and fully reload — measured in 6000.4, 6000.5 and 6000.6 — so nothing below
-shows up until the setting is flipped or a new project is created. Second, a recompile still
-reloads the domain, so the bugs only appear on the *second* play without a code change, which
-is exactly why they survive review.
-
-What the package already does, so the assistant does not re-implement it: at the end of every
-play session it drops subscriptions, retained Sticky and Replay values, and publisher frames
-pushed above the root; at every play entry it resets its diagnostics; it keeps registrations,
-delivery policies, payload types and prefix claims, so a declaration made from a static
-initializer stays declared. See *Entering Play mode without domain reload* in the README.
+The facts behind it, measured in Unity 6000.4 through 6000.6: with domain reload off, static
+fields, static events and static singletons keep the values they had when the previous play
+session ended; static constructors and static field initializers run once per domain and do
+not run again; `[RuntimeInitializeOnLoadMethod]` and the scene lifecycle still run every
+session; a destroyed Unity object still has a live C# reference, so it passes `is null` and
+`?.` and answers `ToString()` with `"null"`; and a recompile still reloads the domain, so all
+of this appears only on the *second* play without a code change. Projects created before 6.6
+carry the old setting and still reload fully until it is flipped.
 
 ---
 
 ```
-Make this project correct when Play mode is entered without a domain reload.
+Make this project's singletons and static state correct when Play mode is entered without
+a domain reload, and move away from singletons where a better shape exists.
 
 Context. Unity 6.6 creates new projects with Edit > Project Settings > Editor > Enter Play
-Mode Settings set to "Reload Scene only", and recommends that setting for existing projects.
-Under it, every static field, static event and static singleton in this project keeps the
-value it had when the previous play session ended. Static constructors and static field
-initializers run once per domain and do not run again. [RuntimeInitializeOnLoadMethod] and
-the scene lifecycle (Awake, OnEnable, OnDestroy) still run every session. A recompile still
-reloads the domain, so this only shows up on the SECOND play without a code change.
+Mode Settings set to "Reload Scene only", and recommends that setting for existing projects;
+the CoreCLR runtime it is moving to has no domain reload at all. Under it, every static
+field, static event and static singleton keeps the value it had when the previous play
+session ended. Static constructors and static field initializers run once per domain and do
+not run again. [RuntimeInitializeOnLoadMethod] and the scene lifecycle (Awake, OnEnable,
+OnDestroy) still run every session. A destroyed Unity object still has a live C# reference:
+it passes `is null`, `?.` and ReferenceEquals, and its ToString() returns "null". A
+recompile still reloads the domain, so all of this shows up only on the SECOND play without
+a code change, which is why it survives review.
 
-EventsPublisher 2.6.1+ handles its own half: at the end of each play session it drops
-subscriptions, retained Sticky/Replay values and publisher frames pushed above the root, and
-at each play entry it resets its diagnostics; it keeps registrations, delivery policies,
-payload types and prefix claims. Do not add code that duplicates that. This prompt is about
-the project's OWN statics.
+## The rule
 
-## The rule to apply to every static
+Classify every static as one of two things, and treat them oppositely.
 
-Classify each static as one of two things, and treat them oppositely:
-
- - A DECLARATION derives from code: an event name, an EventId<T> resolved once, a policy
-   declared with RegisterEvent(name, policy), a lookup table built from an enum, a config
-   constant. It is correct to keep across sessions, and WRONG to reset from a hook, because
-   the static initializer that made it will not run again. Leave these alone. A `static
-   readonly` field whose initializer only reads code is a declaration.
- - RUNTIME STATE describes one play session: a reference to a scene object or component
-   (`Instance`), a bool mirror (`IsInitialized`, `HasSignedIn`, `IsGameOver`), a score, a
-   cache of loaded objects, a static event's subscriber list, a "started" flag in a
-   bootstrapper. It must be reset every session or it lies on the second play.
+ - A DECLARATION derives from code and is the same in every session: an enum-built lookup
+   table, an interned id, a config constant, a registration made from a static initializer.
+   Keep it. Never reset it from a hook — the initializer that made it will not run again,
+   so a reset turns it into a silent absence on the second play.
+ - RUNTIME STATE describes one session: a reference to a scene object or component
+   (`Instance`, `CurrentAvatar`, `CurrentCamera`), a bool mirror (`IsGameStarted`,
+   `IsInitialized`, `HasSignedIn`), a score or counter, a cache of loaded objects, a
+   coroutine host, a static event's subscriber list, a bootstrapper's "started" flag.
+   Reset it every session, by the class that owns it, or it lies on the second play.
 
 ## How to find the work
 
-Do not guess. Enumerate, then classify, then show me the list before changing anything.
+Enumerate first, classify second, and show me the list before changing anything.
 
- 1. Search every non-test assembly for `static` fields and properties that are not `const`
-    and not `static readonly` with a pure initializer; for `static event`; for
-    MonoBehaviour and ScriptableObject types with a static `Instance`; for
-    `DontDestroyOnLoad`; for `[RuntimeInitializeOnLoadMethod]`; and for static constructors
-    that subscribe to anything or register anything.
- 2. For each hit, say which class it is (declaration / runtime state) and what goes wrong on
-    the second play if it is runtime state: a stale reference to a destroyed object, a bool
-    already true at boot so the boot step is skipped, a subscriber list that grows by one
-    per session so handlers fire twice, a value from the last run presented as current.
- 3. Group the runtime state by owner and propose one reset per owner, not a scattering.
+ 1. Search every non-test assembly for: `static` fields and auto-properties that are not
+    `const` and not `static readonly` with a pure initializer; `static event`; any
+    MonoBehaviour or ScriptableObject with a static `Instance`; `DontDestroyOnLoad`;
+    `[RuntimeInitializeOnLoadMethod]`; `[InitializeOnEnterPlayMode]`; static constructors
+    that subscribe to or register anything; Resources.Load or Addressables results stored
+    in statics.
+ 2. For each hit, say which class it is and, for runtime state, what the second play does
+    with it: a handler on a destroyed object throws MissingReferenceException; a bool
+    already true skips a boot step; a subscriber list grows by one per session so handlers
+    fire twice; last session's camera or avatar is used as if it were current.
+ 3. Group runtime state by owner. One reset per owner — not a scattering, and not a global
+    "reset everything" hook.
 
-## How to fix each kind
+## The singleton shapes, and what to do with each
 
- - MonoBehaviour singleton `Instance`: set it in Awake, and clear it in OnDestroy with
-   `if (Instance == this) Instance = null;`. Never test it with `is null` or
-   ReferenceEquals — a destroyed Unity object is not C#-null; only Unity's overloaded `==`
-   knows. Better: stop being a singleton. If the type only publishes or subscribes to
-   events, replace it with EventsFor<T> per upgrade-prompt.md step 4. If it holds real
-   state, make that state a Sticky level event that late subscribers receive on subscribe,
-   so nothing needs a static to poll.
- - Static bool mirrors of events: replace with a Sticky level event (upgrade-prompt.md
-   step 6). The package retains the value within a session and drops it at the end of the
-   session, which is exactly the lifetime the bool was trying to have. If a mirror must
-   stay, reset it in a [RuntimeInitializeOnLoadMethod(SubsystemRegistration)] on the class
-   that owns it.
- - Static events and static subscriber lists in the project's own code: instances subscribe
-   in OnEnable and unsubscribe in OnDisable, never only in Awake. A static system that
-   subscribes from a static constructor subscribes once and then holds a stale delegate;
-   move the subscribe into a [RuntimeInitializeOnLoadMethod] and make it idempotent
-   (`X -= Handler; X += Handler;`), or on Unity 6.5+ pair [OnEnteringPlayMode] with
-   [OnExitingPlayMode]. On Unity 6.6, [AutoStaticsCleanup]
-   (Unity.Scripting.LifecycleManagement) re-evaluates a field's initializer on each play
-   transition and calls Clear() on a `static readonly` collection; use it on runtime state,
-   and [NoAutoStaticsCleanup] to mark a declaration explicitly where the field would
-   otherwise look like state.
- - Bootstrappers with a `static bool _started` guard: the guard is what makes the second
-   play skip startup. Reset it at SubsystemRegistration, or key it off something that is
-   per-session, such as the scene handle.
- - Publisher frames: keep Push on scene load paired with Pop on unload. The package unwinds
-   leaked frames at the end of a session, but a leak within a session still hides events
-   from the frame underneath.
- - Static references to things loaded during play (Addressables handles, instantiated
-   prefabs, RenderTextures): release them at the end of the session or reload them at the
-   start; a handle from the last session points at something already released.
+ A. A MonoBehaviour singleton with a static Instance. Minimum: assign in Awake, and in
+    OnDestroy write `if (Instance == this) Instance = null;` using Unity's `==`, never
+    `is null`. Pick one duplicate policy and keep it everywhere — destroy the newcomer (the
+    usual choice) or replace the survivor — rather than mixing both across singletons. An
+    editor-only [InitializeOnEnterPlayMode] that nulls Instance is a fine belt-and-braces,
+    but OnDestroy is the one that also covers a scene unload mid-session. Non-static
+    instance fields need nothing: the object dies with its scene and a fresh one has fresh
+    fields. Do not put per-session state in statics on a MonoBehaviour just because the
+    class is a singleton; keep it on the instance.
+ B. A static class blackboard: static properties holding the current avatar, path, camera,
+    prescription, coroutine host. All of it is runtime state, and nothing resets it. Give
+    the class one Reset() that returns every member to its default, and call it from a
+    [RuntimeInitializeOnLoadMethod(SubsystemRegistration)] on that class. On Unity 6.6 the
+    same thing is [AutoStaticsCleanup] (Unity.Scripting.LifecycleManagement) on the class,
+    with [NoAutoStaticsCleanup] on any member that is a declaration. Then make the readers
+    tolerate "not set yet" — a blackboard read before its writer has run is the same bug as
+    a stale one.
+ C. A GameState of static bool mirrors (IsGameStarted, IsGameOver, IsPaused...). Resetting
+    them in the owner's Awake works only while the owner lives in the first scene and awakes
+    before every reader; an additively-loaded scene breaks that. Reset them at
+    SubsystemRegistration instead, and prefer replacing the bools with one state enum that
+    is published as a retained event, so readers subscribe rather than poll.
+ D. Static events and static subscriber lists. Instances subscribe in OnEnable and
+    unsubscribe in OnDisable, never only in Awake. A static system that subscribes from a
+    static constructor subscribes once and then holds a stale delegate; move the subscribe
+    into a [RuntimeInitializeOnLoadMethod], make it idempotent (`X -= H; X += H;`), or on
+    Unity 6.5+ pair [OnEnteringPlayMode] with [OnExitingPlayMode]. [AutoStaticsCleanup] on a
+    static event clears its subscriber list on each transition.
+ E. A lazily created singleton (`Instance ??= new GameObject(...).AddComponent<T>()`, often
+    with DontDestroyOnLoad). The static keeps last session's destroyed object, so `??=`
+    sees non-null and hands back a corpse. Check with Unity's `==`
+    (`if (Instance == null) create`), and null it in OnDestroy as in A.
+ F. A ScriptableObject singleton loaded from Resources or Addressables and used to hold
+    runtime values. An asset's fields modified during Play mode keep the modified values for
+    the rest of the editor session, domain reload or not. Runtime values do not belong on an
+    asset: move them to an object created at play start, or reset the asset from a
+    bootstrapper's OnEnable and OnDisable.
+ G. A bootstrapper with a `static bool _started` guard. The guard is what makes the second
+    play skip startup. Reset it at SubsystemRegistration, or key it off something that is
+    per-session, such as a scene handle.
+ H. Static handles to things loaded during play — Addressables handles, instantiated
+    prefabs, RenderTextures. Release them at the end of the session or reload them at the
+    start; a handle from the last session points at something already released.
+
+## Moving away from singletons
+
+Where a singleton exists only so that "anyone can reach it", replace it in this order of
+preference, and tell me which you chose and why:
+
+ 1. Pass it. If two or three components use it, give them a serialized reference or a
+    constructor argument. No static at all.
+ 2. Scope it to a session object. A bootstrapper creates one context object at play start —
+    the first scene's Awake, or a [RuntimeInitializeOnLoadMethod] — that owns every piece of
+    runtime state the singletons held, and disposes it at the end. The former singletons
+    become fields on it. Statics reduce to one: the context, nulled on dispose.
+ 3. Publish the state as a retained event. Readers that only need "the current value"
+    subscribe and receive the latest value on subscribe; nothing polls a static. The value
+    lives on the bus for the session and is dropped with it.
+ 4. Keep the singleton, made lifecycle-correct per A through H. Acceptable for a
+    cross-cutting service — time, audio — with no per-session state beyond Instance.
 
 Where you reset with [RuntimeInitializeOnLoadMethod(SubsystemRegistration)]: ordering among
-entry points in the same phase is undefined, so reset only what THIS class owns. Never clear
-a shared registry, and never drop something another hook in the same phase may have just
-created. A reset that belongs at the END of a session is editor-only by nature — the
-player never has a second session — so it goes in an editor assembly, on
-EditorApplication.playModeStateChanged at EnteredEditMode, after teardown has finished.
+entry points in that phase is undefined, so reset only what THIS class owns — never a shared
+registry, and never something another hook in the same phase may have just created. A reset
+that belongs at the END of a session is editor-only by nature, since a player never has a
+second session; it goes in an editor assembly, on EditorApplication.playModeStateChanged at
+EnteredEditMode, after teardown has finished.
+
+If the project uses EventsPublisher 2.6.1 or later, the bus already drops its own
+subscriptions, retained values and pushed frames at the end of each session and keeps its
+declarations. Do not add resets for it.
 
 ## How to verify
 
 Set Enter Play Mode Settings to "Reload Scene only", then, without recompiling in between:
 
- 1. Enter play mode, run the boot sequence, exit.
+ 1. Enter play mode, run the boot sequence and one full loop of play, exit.
  2. Enter play mode again and run the same sequence.
 
 The second run must be indistinguishable from the first. Look specifically for: a static
-counter you add in a [RuntimeInitializeOnLoadMethod(AfterSceneLoad)] logging 2 — this proves
-statics persisted, so the test is testing the right thing; any StrictMode "is not
-registered" error that did not appear on the first run; any MissingReferenceException from a
-handler; any log line appearing twice that appeared once before; any system that reports
-itself ready before its initialization ran; Window > Events > Upgrade Audit showing the same
-late-delivery list as after the first run. Tell me what you ran and what you saw, run by
-run. Do not report the project as safe without the second run.
+counter you add in a [RuntimeInitializeOnLoadMethod(AfterSceneLoad)] logging 2 — this
+proves statics persisted, so the test is testing the right thing; any
+MissingReferenceException; any log line appearing twice that appeared once before; any
+system reporting itself ready, started or configured before its initialization ran; any
+value from the first run visible at the start of the second — score, avatar, selected
+level. Tell me what you ran and what you saw, run by run. Do not report the project as safe
+without the second run.
 
 ## What not to do
 
  - Do not move a declaration out of a static initializer "to be safe". Declarations belong
-   there; the package keeps them.
+   there.
  - Do not add a global "reset everything" hook. Resets belong to owners.
  - Do not switch the project setting back to "Reload Domain and Scene" as the fix. It hides
-   the problem, and Unity's CoreCLR runtime will not have a domain reload at all.
- - Do not turn off StrictMode to quiet the second run.
+   the problem, and it will not exist under CoreCLR.
+ - Do not check a Unity object for null with `is null`, `?.` or ReferenceEquals.
  - Do not report a static as fixed without saying which of the two classes it is and what
    the second-run check showed.
 ```

--- a/Documentation~/fast-play-mode-prompt.md
+++ b/Documentation~/fast-play-mode-prompt.md
@@ -1,0 +1,137 @@
+# Fast Enter Play Mode prompt
+
+Drop this into an AI coding assistant working in a project that consumes EventsPublisher
+2.6.1 or later and is moving off `EventsPublisherEnumsSingleton<T>` — or off any
+`MonoBehaviour` singleton — while Unity 6.6 makes entering Play mode without a domain reload
+the default. It complements `upgrade-prompt.md`: that one migrates the event calls; this one
+makes the project's **own** static state correct when a play session starts with the
+previous session's statics still in memory.
+
+Two facts to know before pasting it. First, existing projects created before 6.6 still carry
+the old setting and fully reload — measured in 6000.4, 6000.5 and 6000.6 — so nothing below
+shows up until the setting is flipped or a new project is created. Second, a recompile still
+reloads the domain, so the bugs only appear on the *second* play without a code change, which
+is exactly why they survive review.
+
+What the package already does, so the assistant does not re-implement it: at the end of every
+play session it drops subscriptions, retained Sticky and Replay values, and publisher frames
+pushed above the root; at every play entry it resets its diagnostics; it keeps registrations,
+delivery policies, payload types and prefix claims, so a declaration made from a static
+initializer stays declared. See *Entering Play mode without domain reload* in the README.
+
+---
+
+```
+Make this project correct when Play mode is entered without a domain reload.
+
+Context. Unity 6.6 creates new projects with Edit > Project Settings > Editor > Enter Play
+Mode Settings set to "Reload Scene only", and recommends that setting for existing projects.
+Under it, every static field, static event and static singleton in this project keeps the
+value it had when the previous play session ended. Static constructors and static field
+initializers run once per domain and do not run again. [RuntimeInitializeOnLoadMethod] and
+the scene lifecycle (Awake, OnEnable, OnDestroy) still run every session. A recompile still
+reloads the domain, so this only shows up on the SECOND play without a code change.
+
+EventsPublisher 2.6.1+ handles its own half: at the end of each play session it drops
+subscriptions, retained Sticky/Replay values and publisher frames pushed above the root, and
+at each play entry it resets its diagnostics; it keeps registrations, delivery policies,
+payload types and prefix claims. Do not add code that duplicates that. This prompt is about
+the project's OWN statics.
+
+## The rule to apply to every static
+
+Classify each static as one of two things, and treat them oppositely:
+
+ - A DECLARATION derives from code: an event name, an EventId<T> resolved once, a policy
+   declared with RegisterEvent(name, policy), a lookup table built from an enum, a config
+   constant. It is correct to keep across sessions, and WRONG to reset from a hook, because
+   the static initializer that made it will not run again. Leave these alone. A `static
+   readonly` field whose initializer only reads code is a declaration.
+ - RUNTIME STATE describes one play session: a reference to a scene object or component
+   (`Instance`), a bool mirror (`IsInitialized`, `HasSignedIn`, `IsGameOver`), a score, a
+   cache of loaded objects, a static event's subscriber list, a "started" flag in a
+   bootstrapper. It must be reset every session or it lies on the second play.
+
+## How to find the work
+
+Do not guess. Enumerate, then classify, then show me the list before changing anything.
+
+ 1. Search every non-test assembly for `static` fields and properties that are not `const`
+    and not `static readonly` with a pure initializer; for `static event`; for
+    MonoBehaviour and ScriptableObject types with a static `Instance`; for
+    `DontDestroyOnLoad`; for `[RuntimeInitializeOnLoadMethod]`; and for static constructors
+    that subscribe to anything or register anything.
+ 2. For each hit, say which class it is (declaration / runtime state) and what goes wrong on
+    the second play if it is runtime state: a stale reference to a destroyed object, a bool
+    already true at boot so the boot step is skipped, a subscriber list that grows by one
+    per session so handlers fire twice, a value from the last run presented as current.
+ 3. Group the runtime state by owner and propose one reset per owner, not a scattering.
+
+## How to fix each kind
+
+ - MonoBehaviour singleton `Instance`: set it in Awake, and clear it in OnDestroy with
+   `if (Instance == this) Instance = null;`. Never test it with `is null` or
+   ReferenceEquals — a destroyed Unity object is not C#-null; only Unity's overloaded `==`
+   knows. Better: stop being a singleton. If the type only publishes or subscribes to
+   events, replace it with EventsFor<T> per upgrade-prompt.md step 4. If it holds real
+   state, make that state a Sticky level event that late subscribers receive on subscribe,
+   so nothing needs a static to poll.
+ - Static bool mirrors of events: replace with a Sticky level event (upgrade-prompt.md
+   step 6). The package retains the value within a session and drops it at the end of the
+   session, which is exactly the lifetime the bool was trying to have. If a mirror must
+   stay, reset it in a [RuntimeInitializeOnLoadMethod(SubsystemRegistration)] on the class
+   that owns it.
+ - Static events and static subscriber lists in the project's own code: instances subscribe
+   in OnEnable and unsubscribe in OnDisable, never only in Awake. A static system that
+   subscribes from a static constructor subscribes once and then holds a stale delegate;
+   move the subscribe into a [RuntimeInitializeOnLoadMethod] and make it idempotent
+   (`X -= Handler; X += Handler;`), or on Unity 6.5+ pair [OnEnteringPlayMode] with
+   [OnExitingPlayMode]. On Unity 6.6, [AutoStaticsCleanup]
+   (Unity.Scripting.LifecycleManagement) re-evaluates a field's initializer on each play
+   transition and calls Clear() on a `static readonly` collection; use it on runtime state,
+   and [NoAutoStaticsCleanup] to mark a declaration explicitly where the field would
+   otherwise look like state.
+ - Bootstrappers with a `static bool _started` guard: the guard is what makes the second
+   play skip startup. Reset it at SubsystemRegistration, or key it off something that is
+   per-session, such as the scene handle.
+ - Publisher frames: keep Push on scene load paired with Pop on unload. The package unwinds
+   leaked frames at the end of a session, but a leak within a session still hides events
+   from the frame underneath.
+ - Static references to things loaded during play (Addressables handles, instantiated
+   prefabs, RenderTextures): release them at the end of the session or reload them at the
+   start; a handle from the last session points at something already released.
+
+Where you reset with [RuntimeInitializeOnLoadMethod(SubsystemRegistration)]: ordering among
+entry points in the same phase is undefined, so reset only what THIS class owns. Never clear
+a shared registry, and never drop something another hook in the same phase may have just
+created. A reset that belongs at the END of a session is editor-only by nature — the
+player never has a second session — so it goes in an editor assembly, on
+EditorApplication.playModeStateChanged at EnteredEditMode, after teardown has finished.
+
+## How to verify
+
+Set Enter Play Mode Settings to "Reload Scene only", then, without recompiling in between:
+
+ 1. Enter play mode, run the boot sequence, exit.
+ 2. Enter play mode again and run the same sequence.
+
+The second run must be indistinguishable from the first. Look specifically for: a static
+counter you add in a [RuntimeInitializeOnLoadMethod(AfterSceneLoad)] logging 2 — this proves
+statics persisted, so the test is testing the right thing; any StrictMode "is not
+registered" error that did not appear on the first run; any MissingReferenceException from a
+handler; any log line appearing twice that appeared once before; any system that reports
+itself ready before its initialization ran; Window > Events > Upgrade Audit showing the same
+late-delivery list as after the first run. Tell me what you ran and what you saw, run by
+run. Do not report the project as safe without the second run.
+
+## What not to do
+
+ - Do not move a declaration out of a static initializer "to be safe". Declarations belong
+   there; the package keeps them.
+ - Do not add a global "reset everything" hook. Resets belong to owners.
+ - Do not switch the project setting back to "Reload Domain and Scene" as the fix. It hides
+   the problem, and Unity's CoreCLR runtime will not have a domain reload at all.
+ - Do not turn off StrictMode to quiet the second run.
+ - Do not report a static as fixed without saying which of the two classes it is and what
+   the second-run check showed.
+```

--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ after play mode ends. `EventsPublisher.StrictMode` and `EventsDiagnostics.Enable
 ordinary settings and are never reset. *Clear Now* is the stronger operation: it drops
 registrations too, and an annotated family is registered again by the next play entry.
 
+That covers the package's statics. For the project's own — singleton `Instance` fields,
+`bool` mirrors, static events, bootstrap guards — `Documentation~/fast-play-mode-prompt.md`
+is a project-agnostic prompt that classifies each one as a declaration to keep or runtime
+state to reset, and ends with the two-play check the package itself was verified with.
+
 ## Upgrading an existing project
 
 **Window > Events > Upgrade Audit** reflects over the project and reads its assets, then

--- a/README.md
+++ b/README.md
@@ -211,10 +211,11 @@ after play mode ends. `EventsPublisher.StrictMode` and `EventsDiagnostics.Enable
 ordinary settings and are never reset. *Clear Now* is the stronger operation: it drops
 registrations too, and an annotated family is registered again by the next play entry.
 
-That covers the package's statics. For the project's own — singleton `Instance` fields,
-`bool` mirrors, static events, bootstrap guards — `Documentation~/fast-play-mode-prompt.md`
-is a project-agnostic prompt that classifies each one as a declaration to keep or runtime
-state to reset, and ends with the two-play check the package itself was verified with.
+That covers the package's statics. `Documentation~/fast-play-mode-prompt.md` is a general
+prompt, not specific to this package, for the singletons and static state in a Unity project
+itself — a `MonoBehaviour` with a static `Instance`, a static blackboard class, a `GameState`
+of static bools, static events — covering what breaks without a domain reload, what to
+replace each shape with, and the two-play check this package was verified with.
 
 ## Upgrading an existing project
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.crawfissoftware.eventspublisher",
   "displayName": "Events Publisher",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "unity": "2022.3",
   "description": "Lightweight, allocation-safe event/messaging publisher for Unity projects. Editor tooling included.",
   "keywords": [ "events", "messaging", "publisher", "observer", "csharp", "unity" ],


### PR DESCRIPTION
Documentation only; no code change.

Adds `Documentation~/fast-play-mode-prompt.md`: a **general** prompt, not specific to this package, for the singletons and static state in any Unity project under Unity 6.6's default of entering Play mode without a domain reload. It:

- states the rule: a *declaration* derives from code and must be kept, *runtime state* describes one session and must be reset by its owner;
- tells the assistant how to enumerate and classify every static before touching anything;
- catalogues the singleton shapes with the fix for each — a `MonoBehaviour` with a static `Instance`, a static blackboard class, a `GameState` of static bools, static events, lazily created singletons, `ScriptableObject` singletons, bootstrap guards, loaded-asset handles — including the Unity 6.5/6.6 lifecycle attributes and the SubsystemRegistration ordering caveat;
- gives an order of preference for moving away from singletons altogether (pass it, scope it to a session object, publish it as a retained event, or keep it lifecycle-correct);
- ends with the two-play verification the package itself was checked with, and a "what not to do" list.

The package gets one sentence: it handles its own statics, so no resets should be added for it. Linked from the README section *Entering Play mode without domain reload* and from UPGRADING. Versioned 2.6.3 so the file is reachable at a tag; drop the bump if you would rather batch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183sPo9qKxfnfxXwA53raZ9
